### PR TITLE
Fix the bug when set unwarpped positions matrix

### DIFF
--- a/mdpy/core/__init__.py
+++ b/mdpy/core/__init__.py
@@ -4,11 +4,11 @@ __email__ = "zhenyuwei99@gmail.com"
 __copyright__ = "Copyright 2021-2021, Southeast University and Zhenyu Wei"
 __license__ = "GPLv3"
 
-from .particle import Particle
-from .topology import Topology
-from .cell_list import CellList
-from .state import State
-from .trajectory import Trajectory
+from mdpy.core.particle import Particle
+from mdpy.core.topology import Topology
+from mdpy.core.cell_list import CellList
+from mdpy.core.state import State
+from mdpy.core.trajectory import Trajectory
 
 __all__ = [
     'Particle', 'Topology', 'CellList', 'State', 'Trajectory'

--- a/mdpy/core/cell_list.py
+++ b/mdpy/core/cell_list.py
@@ -11,10 +11,10 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import numpy as np
 import numba as nb
-from .. import SPATIAL_DIM, env
-from ..utils import *
-from ..unit import *
-from ..error import *
+from mdpy import SPATIAL_DIM, env
+from mdpy.utils import *
+from mdpy.unit import *
+from mdpy.error import *
 
 class CellList:
     def __init__(self) -> None:

--- a/mdpy/core/state.py
+++ b/mdpy/core/state.py
@@ -10,13 +10,12 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import numpy as np
-# from cupy.cuda.nvtx import RangePush, RangePop
-from .cell_list import CellList
-from .topology import Topology
-from .. import SPATIAL_DIM, env
-from ..unit import *
-from ..error import *
-from ..utils import *
+from mdpy.core.cell_list import CellList
+from mdpy.core.topology import Topology
+from mdpy import SPATIAL_DIM, env
+from mdpy.unit import *
+from mdpy.error import *
+from mdpy.utils import *
 
 class State:
     def __init__(self, topology: Topology) -> None:
@@ -62,10 +61,10 @@ class State:
 
     def set_positions(self, positions: np.ndarray):
         self._check_matrix_shape(positions)
-        self._positions = positions.astype(env.NUMPY_FLOAT)
-        # RangePush('Cell list creation')
+        self._positions = wrap_positions(
+            positions.astype(env.NUMPY_FLOAT), self._pbc_matrix, self._pbc_inv
+        )
         self._cell_list.update(self._positions)
-        # RangePop()
     
     def set_velocities(self, velocities: np.ndarray):
         self._check_matrix_shape(velocities)

--- a/mdpy/ensemble.py
+++ b/mdpy/ensemble.py
@@ -10,10 +10,9 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import numpy as np
-
-from .core import Topology, State
-from .error import *
-from .unit import *
+from mdpy.core import Topology, State
+from mdpy.error import *
+from mdpy.unit import *
 
 class Ensemble:
     def __init__(self, topology: Topology) -> None:
@@ -39,9 +38,6 @@ class Ensemble:
         )
 
     __str__ = __repr__
-
-    def create_segment(self, keywords):
-        pass
 
     def add_constraints(self, *constraints):
         for constraint in constraints:
@@ -99,14 +95,6 @@ class Ensemble:
     @property
     def kinetic_energy(self):
         return self._kinetic_energy
-
-    @property
-    def segments(self):
-        return self._segments
-
-    @property
-    def num_segments(self):
-        return self._num_segments
 
     @property
     def constraints(self):

--- a/mdpy/integrator/__init__.py
+++ b/mdpy/integrator/__init__.py
@@ -4,10 +4,10 @@ __email__ = "zhenyuwei99@gmail.com"
 __copyright__ = "Copyright 2021-2021, Southeast University and Zhenyu Wei"
 __license__ = "GPLv3"
 
-from .integrator import Integrator
+from mdpy.integrator.integrator import Integrator
 
-from .verlet_integrator import VerletIntegrator
-from .langevin_integrator import LangevinIntegrator
+from mdpy.integrator.verlet_integrator import VerletIntegrator
+from mdpy.integrator.langevin_integrator import LangevinIntegrator
 
 __all__ = [
     'VerletIntegrator'

--- a/mdpy/integrator/integrator.py
+++ b/mdpy/integrator/integrator.py
@@ -9,9 +9,9 @@ contact : zhenyuwei99@gmail.com
 copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
-from ..ensemble import Ensemble
-from ..utils import *
-from ..unit import *
+from mdpy.ensemble import Ensemble
+from mdpy.utils import *
+from mdpy.unit import *
 
 class Integrator:
     def __init__(self, time_step) -> None:
@@ -27,10 +27,6 @@ class Integrator:
         raise NotImplementedError(
             'The subclass of mdpy.integrator.Integrator class should overload integrate method'
         )
-
-    def wrap_pbc(self, pbc_matrix, pbc_inv):
-        self._cur_positions = wrap_positions(self._cur_positions, pbc_matrix, pbc_inv)
-        self._pre_positions = wrap_positions(self._pre_positions, pbc_matrix, pbc_inv)
 
     @property
     def time_step(self):

--- a/mdpy/integrator/langevin_integrator.py
+++ b/mdpy/integrator/langevin_integrator.py
@@ -11,10 +11,10 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import numpy as np
 from numpy.random import randn
-from . import Integrator
-from ..ensemble import Ensemble
-from ..unit import *
-from ..utils import *
+from mdpy.integrator import Integrator
+from mdpy.ensemble import Ensemble
+from mdpy.unit import *
+from mdpy.utils import *
 
 class LangevinIntegrator(Integrator):
     def __init__(self, time_step, temperature, friction_factor) -> None:
@@ -62,7 +62,6 @@ class LangevinIntegrator(Integrator):
                 self._b * self._sigma * self._time_step_3_over_2 / 2 * xi_over_sqrt_masses
             ), self._cur_positions
             # Update position
-            self._cur_positions = wrap_positions(self._cur_positions, *ensemble.state.pbc_info)
             ensemble.state.set_positions(self._cur_positions)
             ensemble.update()
             self._cur_acceleration = ensemble.forces / masses

--- a/mdpy/integrator/verlet_integrator.py
+++ b/mdpy/integrator/verlet_integrator.py
@@ -9,10 +9,10 @@ contact : zhenyuwei99@gmail.com
 copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
-from . import Integrator
-from .. import env
-from ..ensemble import Ensemble
-from ..utils import *
+from mdpy import env
+from mdpy.ensemble import Ensemble
+from mdpy.integrator import Integrator
+from mdpy.utils import *
 
 class VerletIntegrator(Integrator):
     def __init__(self, time_step) -> None:
@@ -43,7 +43,6 @@ class VerletIntegrator(Integrator):
                 2 * self._cur_positions - self._pre_positions + 
                 accelration * self._time_step_square
             ), self._cur_positions
-            self._cur_positions = wrap_positions(self._cur_positions, *ensemble.state.pbc_info)
             ensemble.state.set_positions(self._cur_positions)
             # Update step
             cur_step += 1


### PR DESCRIPTION
# Bug descriptions
When setting a positions matrix that contains positions beyond the space defined by the PBC matrix: [-0.5, 0.5] of PBC length, the mdpy.core.CellList class will throwing error. As:
- The number of cell along each direction is defined by PBC
- The belonging of a specific particle is defined within this range
- When position out of range, the index of cell will exceed the boundary

# Update
- mdpy.Ensemble class
- mdpy.core.CellList class
- mdpy.core.State class
- mdpy.integrator package