### PR TITLE
Fix bug when construct cell list with particle on the boundary of pbc

### DIFF
--- a/mdpy/core/cell_list.py
+++ b/mdpy/core/cell_list.py
@@ -16,14 +16,22 @@ from mdpy.utils import *
 from mdpy.unit import *
 from mdpy.error import *
 
+CELL_LIST_SKIN = Quantity(2, angstrom)
+
 class CellList:
-    def __init__(self) -> None:
-        self._cutoff_radius = env.NUMPY_FLOAT(0)
-        self._pbc_diag = np.zeros(SPATIAL_DIM, env.NUMPY_FLOAT)
+    def __init__(self, pbc_matrix: np.ndarray, cutoff_radius=12) -> None:
+        # Read input
+        self.set_pbc_matrix(pbc_matrix, is_update=False)
+        self.set_cutoff_radius(cutoff_radius, is_update=False)
+        # Skin for particles on boundary to be included in cell_list
+        self._cell_list_skin = check_quantity_value(CELL_LIST_SKIN, default_length_unit)
+        # Cell list attributes
         self._num_particles = 0
         self._particle_cell_index = None # N x 3
         self._cell_list = None # n x n x n x Nb
         self._num_particles_per_cell = 0
+        self._update_attributes()
+        # Cell list construction kernel
         self._kernel = nb.njit(
             (env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_INT[::1])
         )(self.kernel)
@@ -33,66 +41,56 @@ class CellList:
         return '<mdpy.core.CellList object with %d x %d x %d cells at %x>' %(
             x, y, z, id(self)
         )
-        
+
     __str__ = __repr__
 
     def __getitem__(self, matrix_id):
         x, y, z = self._particle_cell_index[matrix_id, :]
         return self._cell_list[x, y, z, :]
 
-    def _is_poor_defined(self, verbose=False):
-        if self._cutoff_radius == 0:
-            if verbose:
-                print(
-                    'Cutoff radius is poor defined, current value %.3f' 
-                    %(self._cutoff_radius)
-                )
-            return True
-        elif (self._pbc_diag == 0).all():
-            if verbose:
-                print(
-                    'PBC is poor defined, current diag value is %s'
-                    %(self._pbc_diag)
-                )
-            return True
-        return False
+    def set_pbc_matrix(self, pbc_matrix: np.ndarray, is_update=True):
+        pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
+        self._pbc_matrix = check_pbc_matrix(pbc_matrix)
+        self._pbc_diag = self._pbc_matrix.diagonal()
+        if is_update:
+            self._update_attributes()
 
-    def _update_attributes(self):
-        self._cell_matrix = np.ones(SPATIAL_DIM) * self._cutoff_radius
-        self._num_cells_vec = np.floor(self._pbc_diag / self._cell_matrix).astype(env.NUMPY_INT)
-        for i in self._num_cells_vec:
-            if i == 0:
+    def set_cutoff_radius(self, cutoff_radius, is_update=True):
+        cutoff_radius = check_quantity_value(cutoff_radius, default_length_unit)
+        if cutoff_radius == 0:
+            raise CellListPoorDefinedError(
+                'Cutoff radius is poor defined, current value %.3f'
+                %(cutoff_radius)
+            )
+        cell_matrix = np.ones(SPATIAL_DIM) * cutoff_radius
+        num_cells_vec = np.floor(self._pbc_diag / cell_matrix).astype(env.NUMPY_INT)
+        for i in num_cells_vec:
+            if i < 2:
                 raise CellListPoorDefinedError(
                     'The cutoff_radius is too large to create cell list'
                 )
+        self._cutoff_radius = cutoff_radius
+        if is_update:
+            self._update_attributes()
+
+    def _update_attributes(self):
+        self._cell_matrix = np.ones(SPATIAL_DIM) * self._cutoff_radius
+        self._num_cells_vec = np.floor((self._pbc_diag + self._cell_list_skin) / self._cell_matrix).astype(env.NUMPY_INT)
         # Construct at least 27 cells
         self._num_cells_vec[self._num_cells_vec < 3] = 3
         self._num_cells = env.NUMPY_INT(np.prod(self._num_cells_vec))
-        self._cell_matrix = np.diag(self._pbc_diag / self._num_cells_vec).astype(env.NUMPY_FLOAT)
+        self._cell_matrix = np.diag((self._pbc_diag + self._cell_list_skin) / self._num_cells_vec).astype(env.NUMPY_FLOAT)
         self._cell_inv = np.linalg.inv(self._cell_matrix)
-
-    def set_pbc_matrix(self, pbc_matrix: np.ndarray):
-        self._pbc_diag = pbc_matrix.diagonal()
-        if not self._is_poor_defined():
-            self._update_attributes()
-
-    def set_cutoff_radius(self, cutoff_radius):
-        self._cutoff_radius = check_quantity_value(cutoff_radius, default_length_unit)
-        if not self._is_poor_defined():
-            self._update_attributes()
+        print(self._cell_matrix * self._num_cells_vec)
 
     def update(self, positions: np.ndarray):
-        if not self._is_poor_defined():
-            # Set the position to positive value
-            # Ensure the id calculated by matrix dot corresponds to the cell_list index
-            positive_position = positions - positions.min(0) 
-            self._particle_cell_index, self._cell_list = self._kernel(
-                positive_position, self._cell_inv, self._num_cells_vec
-            )
-            self._num_particles_per_cell = self._cell_list.shape[3]
-        else:
-            self._is_poor_defined(verbose=True)
-            raise CellListPoorDefinedError('Cell list is poorly defined.')
+        # Set the position to positive value
+        # Ensure the id calculated by matrix dot corresponds to the cell_list index
+        positive_position = positions - positions.min(0)
+        self._particle_cell_index, self._cell_list = self.kernel(
+            positive_position, self._cell_inv, self._num_cells_vec
+        )
+        self._num_particles_per_cell = self._cell_list.shape[3]
 
     @staticmethod
     def kernel(positions: np.ndarray, cell_inv: np.ndarray, num_cell_vec: np.ndarray):
@@ -110,7 +108,7 @@ class CellList:
         # Build cell list
         max_num_cell_particles = num_cell_particles.max() # The number of particles of cell that contain the most particles
         cell_list = np.ones((
-            num_cell_vec[0], num_cell_vec[1], 
+            num_cell_vec[0], num_cell_vec[1],
             num_cell_vec[2], max_num_cell_particles
         ), dtype=int_type) * -1
         cur_cell_flag = np.zeros_like(num_cell_particles)
@@ -126,7 +124,7 @@ class CellList:
 
     @property
     def pbc_matrix(self):
-        return np.diag(self._pbc_diag)
+        return self._pbc_matrix
 
     @property
     def cell_matrix(self):

--- a/mdpy/core/cell_list.py
+++ b/mdpy/core/cell_list.py
@@ -87,7 +87,7 @@ class CellList:
         # Set the position to positive value
         # Ensure the id calculated by matrix dot corresponds to the cell_list index
         positive_position = positions - positions.min(0)
-        self._particle_cell_index, self._cell_list = self.kernel(
+        self._particle_cell_index, self._cell_list = self._kernel(
             positive_position, self._cell_inv, self._num_cells_vec
         )
         self._num_particles_per_cell = self._cell_list.shape[3]

--- a/mdpy/core/trajectory.py
+++ b/mdpy/core/trajectory.py
@@ -10,13 +10,13 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import numpy as np
-from . import Topology
-from .. import SPATIAL_DIM, env
-from ..utils import check_quantity_value
-from ..error import *
-from ..unit import *
-from ..utils import *
-from ..utils.select import *
+from mdpy import SPATIAL_DIM, env
+from mdpy.core import Topology
+from mdpy.utils import check_quantity_value
+from mdpy.error import *
+from mdpy.unit import *
+from mdpy.utils import *
+from mdpy.utils.select import *
 
 class Trajectory:
     def __init__(
@@ -57,7 +57,7 @@ class Trajectory:
         # The origin define of pbc_matrix is the stack of 3 column vector
         # While in MDPy the position is in shape of n x 3
         # So the scaled position will be Position * PBC instead of PBC * Position as usual
-        self._pbc_matrix = np.ascontiguousarray(pbc_matrix.T, dtype=env.NUMPY_FLOAT)
+        self._pbc_matrix = np.ascontiguousarray(pbc_matrix, dtype=env.NUMPY_FLOAT)
         self._pbc_inv = np.ascontiguousarray(np.linalg.inv(self._pbc_matrix), dtype=env.NUMPY_FLOAT)
         self._is_pbc_specified = True
 
@@ -107,7 +107,7 @@ class Trajectory:
         else:
             if not isinstance(velocities, type(None)):
                 raise TrajectoryPoorDefinedError('This mdpy.core.Trajectory instance does not contain velocities, keyword velocities should be `None`')
-        
+
         if self._contain_forces:
             if isinstance(forces, type(None)):
                 raise TrajectoryPoorDefinedError('This mdpy.core.Trajectory instance contains forces, keyword forces should be specified')
@@ -130,7 +130,7 @@ class Trajectory:
         # Append data
         if self._contain_positions:
             self._positions = np.vstack([self._positions, positions])
-        
+
         if self._contain_velocities:
             self._velocities = np.vstack([self._velocities, velocities])
 
@@ -173,7 +173,7 @@ class Trajectory:
         if not self._is_pbc_specified:
             raise PBCPoorDefinedError('PBC has not been specified before calling.')
         return self._pbc_matrix
-    
+
     @property
     def pbc_inv(self):
         if not self._is_pbc_specified:

--- a/mdpy/dumper/__init__.py
+++ b/mdpy/dumper/__init__.py
@@ -4,11 +4,11 @@ __email__ = "zhenyuwei99@gmail.com"
 __copyright__ = "Copyright 2021-2021, Southeast University and Zhenyu Wei"
 __license__ = "GPLv3"
 
-from .dumper import Dumper
+from mdpy.dumper.dumper import Dumper
 
-from .pdb_dumper import PDBDumper
-from .log_dumper import LogDumper
-from .hdf5_dumper import HDF5Dumper
+from mdpy.dumper.pdb_dumper import PDBDumper
+from mdpy.dumper.log_dumper import LogDumper
+from mdpy.dumper.hdf5_dumper import HDF5Dumper
 
 __all__ = [
     'PDBDumper',

--- a/mdpy/dumper/dumper.py
+++ b/mdpy/dumper/dumper.py
@@ -13,7 +13,9 @@ from ..simulation import Simulation
 from ..error import *
 
 class Dumper:
-    def __init__(self, file_path: str, dump_frequency: int) -> None:
+    def __init__(self, file_path: str, dump_frequency: int, suffix: str) -> None:
+        if not file_path.endswith(suffix):
+            raise FileFormatError('The file should end with .%s suffix' %suffix)
         if dump_frequency <= 0:
             raise DumperPoorDefinedError(
                 'The dump_frequency of dumper should be a positive integer.'

--- a/mdpy/dumper/hdf5_dumper.py
+++ b/mdpy/dumper/hdf5_dumper.py
@@ -9,14 +9,14 @@ contact : zhenyuwei99@gmail.com
 copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
-from . import Dumper
-from ..io import HDF5Writer
-from ..simulation import Simulation
+from mdpy import Simulation
+from mdpy.dumper import Dumper
+from mdpy.io import HDF5Writer
 
 class HDF5Dumper(Dumper):
     def __init__(self, file_path: str, dump_frequency: int) -> None:
+        super().__init__(file_path, dump_frequency, suffix='hdf5')
         self._writer = HDF5Writer(file_path, 'w')
-        super().__init__(file_path, dump_frequency)
 
     def dump(self, simulation: Simulation):
         if self._num_dumpped_frames == 0:

--- a/mdpy/dumper/hdf5_dumper.py
+++ b/mdpy/dumper/hdf5_dumper.py
@@ -15,8 +15,8 @@ from ..simulation import Simulation
 
 class HDF5Dumper(Dumper):
     def __init__(self, file_path: str, dump_frequency: int) -> None:
-        super().__init__(file_path, dump_frequency)
         self._writer = HDF5Writer(file_path, 'w')
+        super().__init__(file_path, dump_frequency)
 
     def dump(self, simulation: Simulation):
         if self._num_dumpped_frames == 0:

--- a/mdpy/dumper/log_dumper.py
+++ b/mdpy/dumper/log_dumper.py
@@ -11,12 +11,11 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import numpy as np
 from datetime import datetime, timedelta
-from mdpy.error import DumperPoorDefinedError
-from .dumper import Dumper
-from ..simulation import Simulation
-from ..unit import *
-from ..dumper import *
-from mdpy import dumper
+from mdpy.dumper import Dumper
+from mdpy.simulation import Simulation
+from mdpy.unit import *
+from mdpy.dumper import *
+from mdpy.error import *
 
 class LogDumper(Dumper):
     def __init__(
@@ -27,16 +26,16 @@ class LogDumper(Dumper):
         potential_energy: bool=False,
         kinetic_energy: bool=False,
         total_energy: bool=False,
-        temperature: bool=False, 
+        temperature: bool=False,
         pressure: bool=False,
         volume: bool=False,
-        density: bool=False, 
+        density: bool=False,
         cpu_time: bool=False,
         rest_time: bool=False,
         total_step: int=0,
         seperator: str='\t'
     ) -> None:
-        super().__init__(file_path, dump_frequency)
+        super().__init__(file_path, dump_frequency, suffix='log')
         # Input
         self._step = step
         self._sim_time = sim_time

--- a/mdpy/dumper/pdb_dumper.py
+++ b/mdpy/dumper/pdb_dumper.py
@@ -15,8 +15,8 @@ from ..simulation import Simulation
 
 class PDBDumper(Dumper):
     def __init__(self, file_path: str, dump_frequency: int) -> None:
+        super().__init__(file_path, dump_frequency, 'pdb')
         self._writer = PDBWriter(file_path, 'w')
-        super().__init__(file_path, dump_frequency)
 
     def dump(self, simulation: Simulation):
         if self._num_dumpped_frames == 0:

--- a/mdpy/dumper/pdb_dumper.py
+++ b/mdpy/dumper/pdb_dumper.py
@@ -15,8 +15,8 @@ from ..simulation import Simulation
 
 class PDBDumper(Dumper):
     def __init__(self, file_path: str, dump_frequency: int) -> None:
-        super().__init__(file_path, dump_frequency)
         self._writer = PDBWriter(file_path, 'w')
+        super().__init__(file_path, dump_frequency)
 
     def dump(self, simulation: Simulation):
         if self._num_dumpped_frames == 0:

--- a/mdpy/ensemble.py
+++ b/mdpy/ensemble.py
@@ -15,12 +15,12 @@ from mdpy.error import *
 from mdpy.unit import *
 
 class Ensemble:
-    def __init__(self, topology: Topology) -> None:
+    def __init__(self, topology: Topology, pbc_matrix: np.ndarray) -> None:
         if not topology.is_joined:
             topology.join()
         # Read input
         self._topology = topology
-        self._state = State(self._topology)
+        self._state = State(self._topology, pbc_matrix)
         self._matrix_shape = self._state.matrix_shape
         self._forces = np.zeros(self._matrix_shape)
 
@@ -43,7 +43,7 @@ class Ensemble:
         for constraint in constraints:
             if constraint in self._constraints:
                 raise ConstraintConflictError(
-                    '%s has added twice to %s' 
+                    '%s has added twice to %s'
                     %(constraint, self)
                 )
             self._constraints.append(constraint)
@@ -61,7 +61,7 @@ class Ensemble:
             self._potential_energy += constraint.potential_energy
         self._update_kinetic_energy()
         self._total_energy = self._potential_energy + self._kinetic_energy
-    
+
     def _update_kinetic_energy(self):
         # Without reshape, the result of the first sum will be a 1d vector
         # , which will be a matrix after multiple with a 2d vector
@@ -71,7 +71,7 @@ class Ensemble:
         self._kinetic_energy = Quantity(
             self._kinetic_energy, default_velocity_unit**2 * default_mass_unit
         ).convert_to(default_energy_unit).value
-    
+
     @property
     def topology(self):
         return self._topology
@@ -79,19 +79,19 @@ class Ensemble:
     @property
     def state(self):
         return self._state
-    
+
     @property
     def forces(self):
         return self._forces
-    
+
     @property
     def total_energy(self):
         return self._total_energy
-    
+
     @property
     def potential_energy(self):
         return self._potential_energy
-    
+
     @property
     def kinetic_energy(self):
         return self._kinetic_energy
@@ -99,7 +99,7 @@ class Ensemble:
     @property
     def constraints(self):
         return self._constraints
-    
+
     @property
     def num_constraints(self):
         return self._num_constraints

--- a/mdpy/error.py
+++ b/mdpy/error.py
@@ -21,7 +21,7 @@ class EnvironmentVariableError(Exception):
 class UnitDimensionDismatchedError(Exception):
     '''This error occurs when:
     - The base dimension of two quantities is dismatched for a specific operation.
-    
+
     Used in:
     - mdpy.unit.base_dimension
     '''
@@ -30,7 +30,7 @@ class UnitDimensionDismatchedError(Exception):
 class GeomtryDimError(Exception):
     '''This error occurs when:
     - The dimension of geometry, like bond, angle, is mismatched
-    
+
     Used in:
     - mdpy.core.topology
     '''
@@ -55,10 +55,10 @@ class ParticleConflictError(Exception):
     '''This error occurs when:
     - Particle is twice bounded to a Particle instance
     - Particle is bounded to itself
-    - Particle is twice bounded to a Toplogy instance 
+    - Particle is twice bounded to a Toplogy instance
     - Particle appears twice in bond, angle, dihedral or improper
     - The number of particles is mismatched with the dimension of positions, velocities, forces matrix
-    
+
     Used in:
     - mdpy.core.particle
     - mdpy.core.topology
@@ -71,7 +71,7 @@ class ParticleConflictError(Exception):
 class ConstraintConflictError(Exception):
     '''This error occurs when:
     - Constraint is twice bounded to a Ensemble instance
-    
+
     Used in:
     - mdpy.ensemble
     '''
@@ -80,7 +80,7 @@ class ConstraintConflictError(Exception):
 class ModifyJoinedTopologyError(Exception):
     '''This error occurs when:
     - Adding particle or topology geometry to a joined Topology object
-    
+
     Used in:
     - mdpy.core.topology
     '''
@@ -88,8 +88,8 @@ class ModifyJoinedTopologyError(Exception):
 
 class NonBoundedError(Exception):
     '''This error occurs when:
-    - Parent object is not bounded 
-    
+    - Parent object is not bounded
+
     Used in:
     - mdpy.constraint.constraint
     '''
@@ -98,7 +98,7 @@ class NonBoundedError(Exception):
 class FileFormatError(Exception):
     '''This error occurs when:
     - file suffix or prefix appears in an unexpected way
-    
+
     Used in:
     - mdpy.io.charmm_toppar_parser
     - mdpy.io.PDBParser
@@ -114,7 +114,7 @@ class FileFormatError(Exception):
 class PBCPoorDefinedError(Exception):
     '''This error occurs when:
     - Two or more column vector in pbc_matrix is linear corellated
-    
+
     Used in:
     - mdpy.core.state
     '''
@@ -133,7 +133,7 @@ class CellListPoorDefinedError(Exception):
 class TrajectoryPoorDefinedError(Exception):
     '''This error occurs when:
     - Extrating information that have not been contained
-    
+
     Used in:
     -mdpy.core.trajectory
     '''
@@ -142,7 +142,7 @@ class TrajectoryPoorDefinedError(Exception):
 class ParameterPoorDefinedError(Exception):
     '''This error occurs when:
     - Topology connections' parameter is not defined in selected parameter file
-    
+
     Used in:
     - mdpy.forcefield.charmm_forcefield
     '''
@@ -151,7 +151,7 @@ class ParameterPoorDefinedError(Exception):
 class HDF5FilePoorDefinedError(Exception):
     '''This error occurs when:
     - Use hdf5 file that does not meet the requirement of mdpy
-    
+
     Used in:
     - mdpy.io.hdf5_parser
     '''
@@ -173,7 +173,7 @@ class DumperPoorDefinedError(Exception):
     - Dump frequency of dumper object is 0
     - Simulation integrates without adding dumper
     - LogDumper requires rest_time without providing total_step
-    
+
     Used in:
     - mdpy.dumper.dumper
     - mdpy.dumper.log_dumper
@@ -184,7 +184,7 @@ class DumperPoorDefinedError(Exception):
 class SelectionConditionPoorDefinedError(Exception):
     '''This error occurs when:
     - Unsupported selection condition has been used
-    
+
     Used in:
     - mdpy.utils.select_particle
     '''
@@ -193,7 +193,7 @@ class SelectionConditionPoorDefinedError(Exception):
 class AnalyserPoorDefinedError(Exception):
     '''This error occurs when:
     - Analyser's input data does not meet analyser's initial setting
-    
+
     Used in:
     - mdpy.analyser.analyser_result
     - mdpy.analyser.rmsd_analyser
@@ -203,7 +203,7 @@ class AnalyserPoorDefinedError(Exception):
 class AtomLossError(Exception):
     '''This error occurs when:
     - The atom go beyond the range of two PBC images
-    
+
     Used in:
     - mdpy.core.state
     '''

--- a/mdpy/error.py
+++ b/mdpy/error.py
@@ -43,9 +43,9 @@ class ArrayDimError(Exception):
     Used in:
     - mdpy.core.state
     - mdpy.core.trajectory
-    - mdpy.io.HDF5Parser
-    - mdpy.io.PDBParser
-    - mdpy.io.DCDParser
+    - mdpy.io.hdf5_parser
+    - mdpy.io.pdb_parser
+    - mdpy.io.dcd_parser
     - mdpy.utils.pbc
     - mdpy.analyser.mobility_analyser
     '''
@@ -101,13 +101,14 @@ class FileFormatError(Exception):
 
     Used in:
     - mdpy.io.charmm_toppar_parser
-    - mdpy.io.PDBParser
-    - mdpy.io.PDBWriter
-    - mdpy.io.PSFParser
-    - mdpy.io.HDF5Parser
-    - mdpy.io.HDF5Writer
-    - mdpy.io.DCDParser
+    - mdpy.io.pdb_parser
+    - mdpy.io.pdb_writer
+    - mdpy.io.psf_parser
+    - mdpy.io.hdf5_parser
+    - mdpy.io.hdf5_writer
+    - mdpy.io.dcd_parser
     - mdpy.analyser.analyser_result
+    - mdpy.dumper.dumper
     '''
     pass
 
@@ -116,7 +117,8 @@ class PBCPoorDefinedError(Exception):
     - Two or more column vector in pbc_matrix is linear corellated
 
     Used in:
-    - mdpy.core.state
+    - mdpy.utils.pbc
+    - mdpy.core.trajectory
     '''
     pass
 
@@ -162,9 +164,9 @@ class ParserPoorDefinedError(Exception):
     - A complementary property is required while parser init with keywords `is_parse_all=False`
 
     Used in:
-    - mdpy.io.HDF5Parser
-    - mdpy.io.PDBParser
-    - mdpy.io.DCDParser
+    - mdpy.io.hdf5_parser
+    - mdpy.io.pdb_parser
+    - mdpy.io.dcd_parser
     '''
     pass
 

--- a/mdpy/forcefield/charmm_forcefield.py
+++ b/mdpy/forcefield/charmm_forcefield.py
@@ -9,22 +9,25 @@ contact : zhenyuwei99@gmail.com
 copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
-from . import Forcefield
-from ..ensemble import Ensemble
-from ..core import Topology
-from ..io import CharmmTopparParser
-from ..utils import check_quantity_value
-from ..constraint import *
-from ..unit import *
-from ..error import *
+import numpy as np
+from mdpy.forcefield import Forcefield
+from mdpy.ensemble import Ensemble
+from mdpy.core import Topology
+from mdpy.io import CharmmTopparParser
+from mdpy.utils import check_quantity_value, check_pbc_matrix
+from mdpy.constraint import *
+from mdpy.unit import *
+from mdpy.error import *
 
 class CharmmForcefield(Forcefield):
     def __init__(
-        self, topology: Topology, cutoff_radius=12,
-        long_range_solver='PPPM', ewald_error=1e-6,
+        self, topology: Topology, pbc_matrix: np.ndarray,
+        cutoff_radius=12, long_range_solver='PPPM', ewald_error=1e-6,
         is_SHAKE: bool=True
     ) -> None:
         super().__init__(topology)
+        pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
+        self._pbc_matrix = check_pbc_matrix(pbc_matrix)
         self._cutoff_radius = check_quantity_value(cutoff_radius, default_length_unit)
         self._long_range_solver = long_range_solver
         self._ewald_error = ewald_error
@@ -48,53 +51,53 @@ class CharmmForcefield(Forcefield):
                 )
         for bond in self._topology.bonds:
             bond_name = (
-                self._topology.particles[bond[0]].particle_type + '-' + 
+                self._topology.particles[bond[0]].particle_type + '-' +
                 self._topology.particles[bond[1]].particle_type
             )
             if not bond_name in bond_keys:
                 raise ParameterPoorDefinedError(
-                    'The parameter for bond %d-%d (%s) can not be found' 
+                    'The parameter for bond %d-%d (%s) can not be found'
                     %(*bond, bond_name)
-                ) 
+                )
         for angle in self._topology.angles:
             angle_name = (
-                self._topology.particles[angle[0]].particle_type + '-' + 
+                self._topology.particles[angle[0]].particle_type + '-' +
                 self._topology.particles[angle[1]].particle_type + '-' +
                 self._topology.particles[angle[2]].particle_type
             )
             if not angle_name in angle_keys:
                 raise ParameterPoorDefinedError(
-                    'The parameter for angle %d-%d-%d (%s) can not be found' 
+                    'The parameter for angle %d-%d-%d (%s) can not be found'
                     %(*angle, angle_name)
-                ) 
+                )
         for dihedral in self._topology.dihedrals:
             dihedral_name = (
-                self._topology.particles[dihedral[0]].particle_type + '-' + 
+                self._topology.particles[dihedral[0]].particle_type + '-' +
                 self._topology.particles[dihedral[1]].particle_type + '-' +
                 self._topology.particles[dihedral[2]].particle_type + '-' +
                 self._topology.particles[dihedral[3]].particle_type
             )
             if not dihedral_name in dihedral_keys:
                 raise ParameterPoorDefinedError(
-                    'The parameter for dihedral %d-%d-%d-%d (%s) can not be found' 
+                    'The parameter for dihedral %d-%d-%d-%d (%s) can not be found'
                     %(*dihedral, dihedral_name)
-                ) 
+                )
         for improper in self._topology.impropers:
             improper_name = (
-                self._topology.particles[improper[0]].particle_type + '-' + 
+                self._topology.particles[improper[0]].particle_type + '-' +
                 self._topology.particles[improper[1]].particle_type + '-' +
                 self._topology.particles[improper[2]].particle_type + '-' +
                 self._topology.particles[improper[3]].particle_type
             )
             if not improper_name in improper_keys:
                 raise ParameterPoorDefinedError(
-                    'The parameter for improper %d-%d-%d-%d (%s) can not be found' 
+                    'The parameter for improper %d-%d-%d-%d (%s) can not be found'
                     %(*improper, improper_name)
-                ) 
-            
+                )
+
     def create_ensemble(self):
         self.check_parameters()
-        ensemble = Ensemble(self._topology)
+        ensemble = Ensemble(self._topology, self._pbc_matrix)
         constraints = []
         if self._topology.num_particles != 0:
             constraints.append(ElectrostaticConstraint())

--- a/mdpy/io/hdf5_writer.py
+++ b/mdpy/io/hdf5_writer.py
@@ -9,17 +9,17 @@ contact : zhenyuwei99@gmail.com
 copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
-import h5py 
+import h5py
 import numpy as np
-from .. import env
-from ..core import Topology
-from ..utils import check_pbc_matrix, check_quantity_value
-from ..unit import *
-from ..error import *
+from mdpy import env
+from mdpy.core import Topology
+from mdpy.utils import check_pbc_matrix, check_quantity_value
+from mdpy.unit import *
+from mdpy.error import *
 
 class HDF5Writer:
     def __init__(
-        self, file_path: str, mode: str = 'w', 
+        self, file_path: str, mode: str = 'w',
         topology: Topology = Topology(),
         pbc_matrix = np.diag([1]*3).astype(env.NUMPY_FLOAT)
     ) -> None:
@@ -33,8 +33,7 @@ class HDF5Writer:
             )
         self._topology = topology
         pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
-        check_pbc_matrix(pbc_matrix)
-        self._pbc_matrix = pbc_matrix
+        self._pbc_matrix = check_pbc_matrix(pbc_matrix)
 
         with h5py.File(self._file_path, self._mode) as f:
             f.create_group('topology')
@@ -56,7 +55,7 @@ class HDF5Writer:
             is_shape_error = True
         if is_shape_error:
             raise ArrayDimError(
-                'The topology contain %s particles while a positions array with shape %s is provided' 
+                'The topology contain %s particles while a positions array with shape %s is provided'
                 %(self._topology.num_particles, list(shape))
             )
         with h5py.File(self._file_path, 'a') as h5f:
@@ -74,7 +73,7 @@ class HDF5Writer:
         with h5py.File(self._file_path, 'a') as h5f:
             del h5f['pbc_matrix']
             h5f['pbc_matrix'] = self._pbc_matrix
-        
+
     def _write_topology(self):
         with h5py.File(self._file_path, 'a') as h5f:
             del h5f['topology']
@@ -118,15 +117,15 @@ class HDF5Writer:
             h5f['topology/num_dihedrals'] = env.NUMPY_INT(self._topology.num_dihedrals)
             h5f['topology/impropers'] = np.array(self._topology.impropers).astype(env.NUMPY_INT)
             h5f['topology/num_impropers'] = env.NUMPY_INT(self._topology.num_impropers)
-            
+
     @staticmethod
     def _check_none(val, target_type):
         return target_type(val) if not isinstance(val, type(None)) else target_type(-1)
-    
+
     @property
     def file_path(self):
         return self._file_path
-    
+
     @property
     def mode(self):
         return self._mode
@@ -151,6 +150,5 @@ class HDF5Writer:
     @pbc_matrix.setter
     def pbc_matrix(self, pbc_matrix: np.ndarray):
         pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
-        check_pbc_matrix(pbc_matrix)
-        self._pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
+        self._pbc_matrix = check_pbc_matrix(pbc_matrix)
         self._write_pbc_matrix()

--- a/mdpy/io/pdb_writer.py
+++ b/mdpy/io/pdb_writer.py
@@ -11,11 +11,11 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import datetime
 import numpy as np
-from .. import env
-from ..core import Topology
-from ..utils import check_quantity_value, get_included_angle, check_pbc_matrix
-from ..unit import *
-from ..error import *
+from mdpy import env
+from mdpy.core import Topology
+from mdpy.utils import check_quantity_value, get_included_angle, check_pbc_matrix
+from mdpy.unit import *
+from mdpy.error import *
 
 STD_RES_NAMES = [
     'ALA', 'ARG', 'ASN', 'ASP',
@@ -123,20 +123,20 @@ def HETATM(serial, particle_name, molecule_name, chain_id, molecule_id, x, y, z,
 # Serial resname chainid resid
 # TER = 'TER   ' + '%5d' + ' '*6 + '%-4s%1s%5d\n'
 def TER(serial, molecule_name, chain_id, molecule_id):
-    res = 'TER   ' 
+    res = 'TER   '
     len_serial = len('%5d' %serial)
     res += '%5s' %serial + ' ' * (11 - len_serial)
     res += '%-4s%1s' %(molecule_name[:4], chain_id[:1])
     len_molecule_id = len('%4d' %molecule_id)
     res += '%4d' %molecule_id + ' ' * (8 - len_molecule_id) + '\n'
-    return res 
+    return res
 
 END = 'END'
 
 class PDBWriter:
     def __init__(
-        self, file_path: str, mode: str = 'w', 
-        topology: Topology=Topology(), 
+        self, file_path: str, mode: str = 'w',
+        topology: Topology=Topology(),
         pbc_matrix = np.diag([0]*3).astype(env.NUMPY_FLOAT)
     ) -> None:
         if not file_path.endswith('.pdb'):
@@ -165,7 +165,7 @@ class PDBWriter:
             is_shape_error = True
         if is_shape_error:
             raise ArrayDimError(
-                'The topology contain %s particles while a positions array with shape %s is provided' 
+                'The topology contain %s particles while a positions array with shape %s is provided'
                 %(self._topology.num_particles, list(shape))
             )
         # HEADER
@@ -211,7 +211,7 @@ class PDBWriter:
                 # Serial resname chainid resid
                 pre_particle = self._topology.particles[index-1]
                 model += TER(
-                    serial, pre_particle.molecule_type, 
+                    serial, pre_particle.molecule_type,
                     pre_particle.chain_id, pre_particle.molecule_id
                 )
                 serial += 1
@@ -219,27 +219,27 @@ class PDBWriter:
             model += ATOM(
                 serial, particle.particle_name, particle.molecule_type,
                 particle.chain_id, particle.molecule_id,
-                positions[index, 0], positions[index, 1], positions[index, 2], 
+                positions[index, 0], positions[index, 1], positions[index, 2],
                 particle.particle_type
             )
             # if particle.molecule_type in STD_RES_NAMES:
             #     model += ATOM(
             #         serial, particle.particle_name, particle.molecule_type,
             #         particle.chain_id, particle.molecule_id,
-            #         positions[index, 0], positions[index, 1], positions[index, 2], 
+            #         positions[index, 0], positions[index, 1], positions[index, 2],
             #         particle.particle_type
             #     )
             # else:
             #     model += HETATM(
             #         serial, particle.particle_name, particle.molecule_type,
             #         particle.chain_id, particle.molecule_id,
-            #         positions[index, 0], positions[index, 1], positions[index, 2], 
+            #         positions[index, 0], positions[index, 1], positions[index, 2],
             #         particle.particle_type
             #     )
             serial += 1
         pre_particle = self._topology.particles[-1]
         model += TER(
-            serial, pre_particle.molecule_type, 
+            serial, pre_particle.molecule_type,
             pre_particle.chain_id, pre_particle.molecule_id
         )
         model += ENDMDL
@@ -255,7 +255,7 @@ class PDBWriter:
     @property
     def file_path(self):
         return self._file_path
-    
+
     @property
     def mode(self):
         return self._mode
@@ -278,5 +278,5 @@ class PDBWriter:
 
     @pbc_matrix.setter
     def pbc_matrix(self, pbc_matrix: np.ndarray):
-        check_pbc_matrix(pbc_matrix)
-        self._pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
+        pbc_matrix = check_quantity_value(pbc_matrix, default_length_unit)
+        self._pbc_matrix = check_pbc_matrix(pbc_matrix)

--- a/mdpy/simulation.py
+++ b/mdpy/simulation.py
@@ -10,12 +10,12 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import numpy as np
-from .ensemble import Ensemble
-from .integrator import Integrator
-from .minimizer import Minimizer
-from .minimizer import *
-from .error import *
-from .unit import *
+from mdpy.ensemble import Ensemble
+from mdpy.integrator import Integrator
+from mdpy.minimizer import Minimizer
+from mdpy.minimizer import *
+from mdpy.error import *
+from mdpy.unit import *
 
 default_minimizer = SteepestDescentMinimizer(0.01, kilojoule_permol, 'kj/mol', is_verbose=False)
 
@@ -46,7 +46,7 @@ class Simulation:
         for dumper in self._dumpers:
             if self._cur_step % dumper.dump_frequency == 0:
                 dumper.dump(self)
-    
+
     def dump_initial_state(self):
         for dumper in self._dumpers:
             dumper.dump(self)

--- a/mdpy/test/test_analyser_result.py
+++ b/mdpy/test/test_analyser_result.py
@@ -12,9 +12,9 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 import pytest
 import os
 import numpy as np
-from ..analyser import AnalyserResult, load_analyser_result
-from ..error import *
-from ..unit import *
+from mdpy.analyser import AnalyserResult, load_analyser_result
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')

--- a/mdpy/test/test_cell_list.py
+++ b/mdpy/test/test_cell_list.py
@@ -11,37 +11,37 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from ..core import CellList
-from ..io import PDBParser
-from ..unit import *
-from ..error import *
+from mdpy.core import CellList
+from mdpy.io import PDBParser
+from mdpy.unit import *
+from mdpy.error import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
 
 class TestCellList:
     def setup(self):
-        self.cell_list = CellList()
+        self.cell_list = CellList(np.diag([30, 30, 30]), Quantity(9, angstrom))
 
     def teardown(self):
         self.cell_list = None
 
     def test_attributes(self):
-        assert self.cell_list.cutoff_radius == 0
-        assert self.cell_list.pbc_matrix[0, 0] == 0
-        assert self.cell_list._is_poor_defined() == True
+        assert self.cell_list.cutoff_radius == 9
+        assert self.cell_list.pbc_matrix[0, 0] == 30
 
     def test_exceptions(self):
         with pytest.raises(UnitDimensionDismatchedError):
             self.cell_list.set_cutoff_radius(Quantity(1, second))
 
         with pytest.raises(CellListPoorDefinedError):
-            self.cell_list.update(np.ones([4, 3]))
+            self.cell_list.set_cutoff_radius(0)
+
+        with pytest.raises(CellListPoorDefinedError):
+            self.cell_list.set_cutoff_radius(24)
 
     def test_update(self):
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
-        self.cell_list.set_cutoff_radius(Quantity(9, angstrom))
-        self.cell_list.set_pbc_matrix(np.diag([30, 30, 30]))
         self.cell_list.update(pdb.positions)
         cell_id = np.floor(np.dot(pdb.positions - pdb.positions.min(0), self.cell_list.cell_inv))
         # cell_id -= cell_id.min(0)
@@ -54,9 +54,8 @@ class TestCellList:
         for index, atom in enumerate(atoms):
             assert atom == self.cell_list.cell_list[0, 0, 0, index]
 
-        # ATOM     24  HB1 PHE A   2      -2.752  -0.222   1.686  1.00  0.00      A     
+        # ATOM     24  HB1 PHE A   2      -2.752  -0.222   1.686  1.00  0.00      A
         assert 23 in self.cell_list[-1, -1, 0]
         # ATOM     39  N   ALA A   3      -0.248  -0.263  -1.755  1.00  0.00      A    N
         assert 38 in self.cell_list[-1, -1, -1]
 
-    

--- a/mdpy/test/test_charmm_angle_constraint.py
+++ b/mdpy/test/test_charmm_angle_constraint.py
@@ -11,14 +11,14 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..constraint import CharmmAngleConstraint
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..io import CharmmTopparParser
-from ..utils import get_angle, get_unit_vec
-from ..error import *
-from ..unit import *
+from mdpy import env
+from mdpy.constraint import CharmmAngleConstraint
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.io import CharmmTopparParser
+from mdpy.utils import get_angle, get_unit_vec
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -26,22 +26,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestCharmmAngleConstraint:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_name='C', 
+            particle_id=0, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
         p2 = Particle(
-            particle_id=1, particle_name='C', 
+            particle_id=1, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=14, charge=0
         )
         p3 = Particle(
-            particle_id=2, particle_name='H', 
+            particle_id=2, particle_name='H',
             particle_type='HA1', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_name='C', 
+            particle_id=3, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -54,8 +54,7 @@ class TestCharmmAngleConstraint:
         velocities = np.array([
             [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]
         ])
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(positions)
         self.ensemble.state.set_velocities(velocities)
@@ -126,4 +125,3 @@ class TestCharmmAngleConstraint:
         k, theta0, ku, u0 = self.parameters['angle']['CA-CA-CA']
         theta = get_angle([0, 0, 0], [1, 0, 0], [0, 0, 1])
         assert energy == pytest.approx(env.NUMPY_FLOAT(k * (theta - theta0)**2 + ku * (1 - u0)**2))
-        

--- a/mdpy/test/test_charmm_bond_constraint.py
+++ b/mdpy/test/test_charmm_bond_constraint.py
@@ -11,14 +11,14 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..constraint import CharmmBondConstraint
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..io import CharmmTopparParser
-from ..utils import get_bond
-from ..error import *
-from ..unit import *
+from mdpy import env
+from mdpy.constraint import CharmmBondConstraint
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.io import CharmmTopparParser
+from mdpy.utils import get_bond
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -26,22 +26,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestCharmmBondConstraint:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_name='C', 
+            particle_id=0, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
         p2 = Particle(
-            particle_id=1, particle_name='N', 
+            particle_id=1, particle_name='N',
             particle_type='N', molecule_type='ASN',
             mass=14, charge=0
         )
         p3 = Particle(
-            particle_id=2, particle_name='H', 
+            particle_id=2, particle_name='H',
             particle_type='HA1', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_name='C', 
+            particle_id=3, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -54,8 +54,7 @@ class TestCharmmBondConstraint:
         velocities = np.array([
             [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]
         ])
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(positions)
         self.ensemble.state.set_velocities(velocities)
@@ -87,7 +86,7 @@ class TestCharmmBondConstraint:
         assert self.constraint._int_parameters[0][1] == 3
         assert self.constraint._float_parameters[0][0] == Quantity(305, kilocalorie_permol).convert_to(default_energy_unit).value
         assert self.constraint._float_parameters[0][1] == Quantity(1.3750, angstrom).convert_to(default_length_unit).value
-        
+
         # No exception
         self.constraint._check_bound_state()
 
@@ -96,7 +95,7 @@ class TestCharmmBondConstraint:
         self.constraint.update()
         forces = self.constraint.forces
         assert forces[1, 0] == 0
-        assert forces[2, 1] == 0 
+        assert forces[2, 1] == 0
 
         bond_length = get_bond([0, 0, 0], [0, 0, 1])
         k, r0 = self.parameters['bond']['CA-CA']

--- a/mdpy/test/test_charmm_dihedral_constraint.py
+++ b/mdpy/test/test_charmm_dihedral_constraint.py
@@ -11,14 +11,14 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..constraint import CharmmDihedralConstraint
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..io import CharmmTopparParser
-from ..utils import get_dihedral
-from ..error import *
-from ..unit import *
+from mdpy import env
+from mdpy.constraint import CharmmDihedralConstraint
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.io import CharmmTopparParser
+from mdpy.utils import get_dihedral
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -26,22 +26,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestCharmmDihedralConstraint:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_name='C', 
+            particle_id=0, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
         p2 = Particle(
-            particle_id=1, particle_name='N', 
+            particle_id=1, particle_name='N',
             particle_type='NY', molecule_type='ASN',
             mass=14, charge=0
         )
         p3 = Particle(
-            particle_id=2, particle_name='CA', 
+            particle_id=2, particle_name='CA',
             particle_type='CPT', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_name='C', 
+            particle_id=3, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -55,8 +55,7 @@ class TestCharmmDihedralConstraint:
         velocities = np.array([
             [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]
         ])
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(positions)
         self.ensemble.state.set_velocities(velocities)
@@ -93,12 +92,12 @@ class TestCharmmDihedralConstraint:
         assert self.constraint._float_parameters[0][2] == np.deg2rad(Quantity(180).value)
 
         # No exception
-        self.constraint._check_bound_state() 
+        self.constraint._check_bound_state()
 
-    def test_update(self):    
+    def test_update(self):
         self.ensemble.add_constraints(self.constraint)
         self.constraint.update()
-        
+
         forces = self.constraint.forces
         k, n, delta = self.parameters['dihedral']['CA-NY-CPT-CA'][0]
         theta = get_dihedral([0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], is_angular=False)
@@ -115,7 +114,7 @@ class TestCharmmDihedralConstraint:
         res = (
             np.cross(vec_oa, forces[0, :]) +
             np.cross(vec_ob, forces[1, :]) +
-            np.cross(vec_oc, forces[2, :]) + 
+            np.cross(vec_oc, forces[2, :]) +
             np.cross(vec_od, forces[3, :])
         )
         assert res[0] == pytest.approx(0, abs=1e-8)

--- a/mdpy/test/test_charmm_forcefield.py
+++ b/mdpy/test/test_charmm_forcefield.py
@@ -11,9 +11,9 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from ..io import PSFParser, CharmmTopparParser
-from ..forcefield import CharmmForcefield
-from ..error import *
+from mdpy.io import PSFParser, CharmmTopparParser
+from mdpy.forcefield import CharmmForcefield
+from mdpy.error import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -29,7 +29,9 @@ class TestCharmmForcefield:
         pass
 
     def test_exceptions(self):
-        pass
+        with pytest.raises(PBCPoorDefinedError):
+            topology = PSFParser(self.psf_file_path).topology
+            CharmmForcefield(topology, np.diag([0, 30, 30]))
 
     def test_check_parameters(self):
         f1 = os.path.join(data_dir, 'toppar_water_ions_namd.str')
@@ -38,7 +40,7 @@ class TestCharmmForcefield:
         charmm_file = CharmmTopparParser(f1, f2, f3)
         parameters = charmm_file.parameters
         topology = PSFParser(self.psf_file_path).topology
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.diag([30, 30, 30]))
         forcefield._parameters = parameters
         forcefield.check_parameters()
 
@@ -47,7 +49,7 @@ class TestCharmmForcefield:
         f2 = os.path.join(data_dir, 'par_all36_prot.prm')
         f3 = os.path.join(data_dir, 'top_all36_prot.rtf')
         topology = PSFParser(self.psf_file_path).topology
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.diag([30, 30, 30]))
         forcefield.set_param_files(f1, f2, f3)
         ensemble = forcefield.create_ensemble()
         assert ensemble.num_constraints == 6

--- a/mdpy/test/test_charmm_improper_constraint.py
+++ b/mdpy/test/test_charmm_improper_constraint.py
@@ -11,14 +11,14 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..constraint import CharmmImproperConstraint
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..io import CharmmTopparParser
-from ..utils import *
-from ..error import *
-from ..unit import *
+from mdpy import env
+from mdpy.constraint import CharmmImproperConstraint
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.io import CharmmTopparParser
+from mdpy.utils import *
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -26,22 +26,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestCharmmImproperConstraint:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_name='H', 
+            particle_id=0, particle_name='H',
             particle_type='HE2', molecule_type='ASN',
             mass=12, charge=0
         )
         p2 = Particle(
-            particle_id=1, particle_name='H', 
+            particle_id=1, particle_name='H',
             particle_type='HE2', molecule_type='ASN',
             mass=14, charge=0
         )
         p3 = Particle(
-            particle_id=2, particle_name='C', 
+            particle_id=2, particle_name='C',
             particle_type='CE2', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_name='C', 
+            particle_id=3, particle_name='C',
             particle_type='CE2', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -55,8 +55,7 @@ class TestCharmmImproperConstraint:
         velocities = np.array([
             [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]
         ])
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(positions)
         self.ensemble.state.set_velocities(velocities)
@@ -83,7 +82,7 @@ class TestCharmmImproperConstraint:
         assert self.constraint._parent_ensemble.num_constraints == 1
         assert self.constraint.num_impropers == 1
 
-        # HE2  HE2  CE2  CE2     3.0            0      0.00   
+        # HE2  HE2  CE2  CE2     3.0            0      0.00
         assert self.constraint._int_parameters[0][0] == 0
         assert self.constraint._int_parameters[0][1] == 1
         assert self.constraint._int_parameters[0][2] == 2
@@ -114,7 +113,7 @@ class TestCharmmImproperConstraint:
         res = (
             np.cross(vec_oa, forces[0, :]) +
             np.cross(vec_ob, forces[1, :]) +
-            np.cross(vec_oc, forces[2, :]) + 
+            np.cross(vec_oc, forces[2, :]) +
             np.cross(vec_od, forces[3, :])
         )
         assert res[0] == pytest.approx(0, abs=1e-8)

--- a/mdpy/test/test_charmm_nonbonded_constraint.py
+++ b/mdpy/test/test_charmm_nonbonded_constraint.py
@@ -11,15 +11,15 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..constraint import CharmmNonbondedConstraint
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..io import CharmmTopparParser
-from ..io.charmm_toppar_parser import RMIN_TO_SIGMA_FACTOR
-from ..utils import get_unit_vec
-from ..error import *
-from ..unit import *
+from mdpy import env
+from mdpy.constraint import CharmmNonbondedConstraint
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.io import CharmmTopparParser
+from mdpy.io.charmm_toppar_parser import RMIN_TO_SIGMA_FACTOR
+from mdpy.utils import get_unit_vec
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -27,22 +27,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestCharmmNonbondedConstraint:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_name='C', 
+            particle_id=0, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
         p2 = Particle(
-            particle_id=1, particle_name='N', 
+            particle_id=1, particle_name='N',
             particle_type='NY', molecule_type='ASN',
             mass=14, charge=0
         )
         p3 = Particle(
-            particle_id=2, particle_name='CA', 
+            particle_id=2, particle_name='CA',
             particle_type='CPT', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_name='C', 
+            particle_id=3, particle_name='C',
             particle_type='CA', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -55,8 +55,7 @@ class TestCharmmNonbondedConstraint:
         velocities = np.array([
             [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 0]
         ]).astype(env.NUMPY_FLOAT)
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(5)
         self.ensemble.state.set_positions(self.p)
         self.ensemble.state.set_velocities(velocities)
@@ -84,7 +83,7 @@ class TestCharmmNonbondedConstraint:
         assert self.constraint._parent_ensemble.num_constraints == 1
 
         # CA     0.000000  -0.070000     1.992400
-        # NY     0.000000  -0.200000     1.850000 
+        # NY     0.000000  -0.200000     1.850000
         # CPT    0.000000  -0.099000     1.860000
         self.ensemble.state.set_pbc_matrix(self.pbc)
         assert self.constraint._parameters_list[0, 0] == Quantity(0.07, kilocalorie_permol).convert_to(default_energy_unit).value
@@ -99,12 +98,12 @@ class TestCharmmNonbondedConstraint:
         self.ensemble.add_constraints(self.constraint)
         self.ensemble.state.cell_list.update(self.ensemble.state.positions)
         # CA     0.000000  -0.070000     1.992400
-        # NY     0.000000  -0.200000     1.850000 
+        # NY     0.000000  -0.200000     1.850000
         # CPT    0.000000  -0.099000     1.860000
         self.constraint.update()
         forces = self.constraint.forces
         assert forces.sum() == pytest.approx(0, abs=1e-8)
-        
+
         epsilon = np.sqrt(
             Quantity(0.07, kilocalorie_permol).convert_to(default_energy_unit).value *
             Quantity(0.099, kilocalorie_permol).convert_to(default_energy_unit).value
@@ -126,5 +125,5 @@ class TestCharmmNonbondedConstraint:
         )
         sigma = (1.9924 + 1.85) * RMIN_TO_SIGMA_FACTOR
         scaled_r = sigma / 1
-        energy_ref = 4 * epsilon * (scaled_r**12 - scaled_r**6) 
+        energy_ref = 4 * epsilon * (scaled_r**12 - scaled_r**6)
         assert energy == pytest.approx(env.NUMPY_FLOAT(energy_ref), abs=1e-3)

--- a/mdpy/test/test_conjugate_gradient_minimizer.py
+++ b/mdpy/test/test_conjugate_gradient_minimizer.py
@@ -10,11 +10,11 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import pytest, os
-import numpy as np 
-from ..io import PDBParser, PSFParser 
-from ..forcefield import CharmmForcefield
-from ..minimizer import ConjugateGradientMinimizer
-from ..unit import *
+import numpy as np
+from mdpy.io import PDBParser, PSFParser
+from mdpy.forcefield import CharmmForcefield
+from mdpy.minimizer import ConjugateGradientMinimizer
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -37,15 +37,14 @@ class TestConjugrateGradientMinimizer:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
-        ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
         ensemble.state.cell_list.set_cutoff_radius(12)
         ensemble.state.set_positions(pdb.positions)
         ensemble.state.set_velocities_to_temperature(300)
         ensemble.update()
         pre_energy = ensemble.potential_energy
         minimizer = ConjugateGradientMinimizer()
-        minimizer.minimize(ensemble, 0.01, 10)
+        minimizer.minimize(ensemble, 0.01, 2)
         assert ensemble.potential_energy < pre_energy

--- a/mdpy/test/test_dumper.py
+++ b/mdpy/test/test_dumper.py
@@ -10,7 +10,8 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import pytest, os
-from ..dumper import Dumper
+from mdpy.dumper import Dumper
+from mdpy.error import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 out_dir = os.path.join(cur_dir, 'out')
@@ -23,15 +24,18 @@ class TestDumper:
         pass
 
     def test_attributes(self):
-        dumper = Dumper(self.file, 1)
+        dumper = Dumper(self.file, 1, 'txt')
         assert dumper.file_path == os.path.join(out_dir, 'test_dumper.txt')
         assert dumper.dump_frequency == 1
 
     def test_exceptions(self):
-        dumper = Dumper(self.file, 1)
+        dumper = Dumper(self.file, 1, 'txt')
         with pytest.raises(NotImplementedError):
             dumper.dump(1)
 
+        with pytest.raises(FileFormatError):
+            Dumper(self.file, 1, 'tt')
+
     def test_dump_info(self):
-        dumper = Dumper(self.file, 1)
+        dumper = Dumper(self.file, 1, 'txt')
         dumper._dump_info('test dump info')

--- a/mdpy/test/test_electrostatic_constraint.py
+++ b/mdpy/test/test_electrostatic_constraint.py
@@ -11,13 +11,13 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..constraint import ElectrostaticConstraint
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..utils import get_unit_vec
-from ..error import *
-from ..unit import *
+from mdpy import env
+from mdpy.constraint import ElectrostaticConstraint
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.utils import get_unit_vec
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -25,22 +25,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestElectrostaticConstraint:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_type='C', 
+            particle_id=0, particle_type='C',
             particle_name='CA', molecule_type='ASN',
             mass=12, charge=1
         )
         p2 = Particle(
-            particle_id=1, particle_type='N', 
+            particle_id=1, particle_type='N',
             particle_name='NY', molecule_type='ASN',
             mass=14, charge=2
         )
         p3 = Particle(
-            particle_id=2, particle_type='CA', 
+            particle_id=2, particle_type='CA',
             particle_name='CPT', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_type='C', 
+            particle_id=3, particle_type='C',
             particle_name='CA', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -50,8 +50,7 @@ class TestElectrostaticConstraint:
         self.p = np.array([
             [0, 0, 0], [0, 10, 0], [0, 21, 0], [0, 11, 0]
         ])
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(self.p)
         self.constraint = ElectrostaticConstraint()
@@ -75,7 +74,7 @@ class TestElectrostaticConstraint:
         self.ensemble.state.set_pbc_matrix(self.pbc)
         self.ensemble.add_constraints(self.constraint)
         self.constraint.update()
-        
+
         forces = self.constraint.forces
         assert forces[2, 0] == 0
         assert forces[3, 1] == 0

--- a/mdpy/test/test_ensemble.py
+++ b/mdpy/test/test_ensemble.py
@@ -13,12 +13,12 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..io import CharmmTopparParser, PSFParser
-from ..constraint import *
-from ..error import *
-from ..unit import *
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.io import CharmmTopparParser, PSFParser
+from mdpy.constraint import *
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -26,22 +26,22 @@ data_dir = os.path.join(cur_dir, 'data')
 class TestEnsemble:
     def setup(self):
         p1 = Particle(
-            particle_id=0, particle_type='C', 
+            particle_id=0, particle_type='C',
             particle_name='CA', molecule_type='ASN',
             mass=12, charge=0
         )
         p2 = Particle(
-            particle_id=1, particle_type='N', 
+            particle_id=1, particle_type='N',
             particle_name='N', molecule_type='ASN',
             mass=14, charge=0
         )
         p3 = Particle(
-            particle_id=2, particle_type='H', 
+            particle_id=2, particle_type='H',
             particle_name='HA', molecule_type='ASN',
             mass=1, charge=0
         )
         p4 = Particle(
-            particle_id=3, particle_type='C', 
+            particle_id=3, particle_type='C',
             particle_name='CB', molecule_type='ASN',
             mass=12, charge=0
         )
@@ -58,8 +58,7 @@ class TestEnsemble:
         velocities = np.array([
             [0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]
         ])
-        self.ensemble = Ensemble(t)
-        self.ensemble.state.set_pbc_matrix(np.eye(3)*30)
+        self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(positions)
         self.ensemble.state.set_velocities(velocities)
@@ -80,12 +79,11 @@ class TestEnsemble:
         charmm_file = CharmmTopparParser(f2, f3)
         parameters = charmm_file.parameters
         topology = PSFParser(psf_file_path).topology
-        ensemble = Ensemble(topology)
-        ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*30))
+        ensemble = Ensemble(topology, np.diag(np.ones(3)*30))
         constraint = CharmmNonbondedConstraint(parameters['nonbonded'])
         ensemble.add_constraints(constraint)
         assert ensemble.num_constraints == 1
-        
+
         with pytest.raises(ConstraintConflictError):
             ensemble.add_constraints(constraint)
 

--- a/mdpy/test/test_hdf5_dumper.py
+++ b/mdpy/test/test_hdf5_dumper.py
@@ -12,22 +12,22 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 import pytest, os
 import numpy as np
 import h5py
-from .. import env
-from ..io import PDBParser, PSFParser
-from ..ensemble import Ensemble
-from ..integrator import Integrator
-from ..simulation import Simulation
-from ..dumper import HDF5Dumper
+from mdpy import env
+from mdpy.io import PDBParser, PSFParser
+from mdpy.ensemble import Ensemble
+from mdpy.integrator import Integrator
+from mdpy.simulation import Simulation
+from mdpy.dumper import HDF5Dumper
+from mdpy.error import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
 out_dir = os.path.join(cur_dir, 'out')
 
-class TestPDBDumper:
+class TestHDF5Dumper:
     def setup(self):
         self.topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
-        self.ensemble = Ensemble(self.topology)
-        self.ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
+        self.ensemble = Ensemble(self.topology, np.diag(np.ones(3)*100))
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         positions = PDBParser(os.path.join(data_dir, '6PO6.pdb')).positions
         self.ensemble.state.set_positions(np.ascontiguousarray(positions).astype(env.NUMPY_FLOAT))
@@ -45,7 +45,8 @@ class TestPDBDumper:
         pass
 
     def test_exceptions(self):
-        pass
+        with pytest.raises(FileFormatError):
+            HDF5Dumper('test.hd', 1)
 
     def test_dump(self):
         dumper = HDF5Dumper(self.file_path, 1)

--- a/mdpy/test/test_langevin_integrator.py
+++ b/mdpy/test/test_langevin_integrator.py
@@ -10,11 +10,11 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import pytest, os
-import numpy as np 
-from ..io import PDBParser, PSFParser 
-from ..forcefield import CharmmForcefield
-from ..integrator import LangevinIntegrator
-from ..unit import *
+import numpy as np
+from mdpy.io import PDBParser, PSFParser
+from mdpy.forcefield import CharmmForcefield
+from mdpy.integrator import LangevinIntegrator
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -37,10 +37,9 @@ class TestVerletIntegrator:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
-        ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
         ensemble.state.cell_list.set_cutoff_radius(12)
         ensemble.state.set_positions(pdb.positions)
         ensemble.state.set_velocities_to_temperature(300)

--- a/mdpy/test/test_log_dumper.py
+++ b/mdpy/test/test_log_dumper.py
@@ -11,13 +11,13 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from ..io import PSFParser, PDBParser
-from ..forcefield import CharmmForcefield
-from ..integrator import VerletIntegrator
-from ..simulation import Simulation
-from ..dumper import LogDumper
-from ..error import *
-from ..unit import *
+from mdpy.io import PSFParser, PDBParser
+from mdpy.forcefield import CharmmForcefield
+from mdpy.integrator import VerletIntegrator
+from mdpy.simulation import Simulation
+from mdpy.dumper import LogDumper
+from mdpy.error import *
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -44,14 +44,13 @@ class TestLogDumper:
 
         topology = psf.topology
 
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.eye(3) * 100)
         forcefield.set_param_files(
             os.path.join(data_dir, 'par_all36_prot.prm'),
             os.path.join(data_dir, 'toppar_water_ions_namd.str')
         )
 
         ensemble = forcefield.create_ensemble()
-        ensemble.state.set_pbc_matrix(np.eye(3) * 100)
         ensemble.state.cell_list.set_cutoff_radius(12)
         ensemble.state.set_positions(pdb.positions)
         ensemble.state.set_velocities_to_temperature(Quantity(300, kelvin))
@@ -63,9 +62,9 @@ class TestLogDumper:
             self.log_file, dump_interval,
             step=True, sim_time=True,
             volume=True, density=True,
-            potential_energy=True, 
-            kinetic_energy=True, 
-            total_energy=True, 
+            potential_energy=True,
+            kinetic_energy=True,
+            total_energy=True,
             temperature=True
         )
         log_dumper.dump(simulation)

--- a/mdpy/test/test_log_dumper.py
+++ b/mdpy/test/test_log_dumper.py
@@ -37,6 +37,9 @@ class TestLogDumper:
         with pytest.raises(DumperPoorDefinedError):
             LogDumper(self.log_file, 100, rest_time=True)
 
+        with pytest.raises(FileFormatError):
+            LogDumper('test.lo', 10)
+
     def test_dump(self):
         prot_name = '6PO6'
         psf = PSFParser(os.path.join(data_dir, prot_name + '.psf'))

--- a/mdpy/test/test_minimizer.py
+++ b/mdpy/test/test_minimizer.py
@@ -10,13 +10,14 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import pytest
-from ..core import Topology
-from ..ensemble import Ensemble
-from ..minimizer import Minimizer
+import numpy as np
+from mdpy.core import Topology
+from mdpy.ensemble import Ensemble
+from mdpy.minimizer import Minimizer
 
 class TestMinimizer:
     def setup(self):
-        self.ensemble = Ensemble(Topology())
+        self.ensemble = Ensemble(Topology(), np.diag([30]*3))
         self.minimizer = Minimizer()
 
     def teardown(self):

--- a/mdpy/test/test_pbc.py
+++ b/mdpy/test/test_pbc.py
@@ -11,9 +11,9 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest
 import numpy as np
-from ..utils import *
-from ..error import *
-from .. import env
+from mdpy import env
+from mdpy.utils import *
+from mdpy.error import *
 
 pbc_matrix = np.diag(np.ones(3)*10).astype(env.NUMPY_FLOAT)
 pbc_inv = np.linalg.inv(pbc_matrix).astype(env.NUMPY_FLOAT)

--- a/mdpy/test/test_pdb_dumper.py
+++ b/mdpy/test/test_pdb_dumper.py
@@ -11,12 +11,13 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest, os
 import numpy as np
-from .. import env
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..integrator import Integrator
-from ..simulation import Simulation
-from ..dumper import PDBDumper
+from mdpy import env
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.integrator import Integrator
+from mdpy.simulation import Simulation
+from mdpy.dumper import PDBDumper
+from mdpy.error import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 out_dir = os.path.join(cur_dir, 'out')
@@ -25,54 +26,53 @@ class TestPDBDumper:
     def setup(self):
         self.particles = []
         self.particles.append(Particle(
-            particle_type='C', particle_name='CA', 
+            particle_type='C', particle_name='CA',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='N', particle_name='N', 
+            particle_type='N', particle_name='N',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='C', particle_name='CB', 
+            particle_type='C', particle_name='CB',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='O', particle_name='O', 
+            particle_type='O', particle_name='O',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='C', particle_name='CA', 
+            particle_type='C', particle_name='CA',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='N', particle_name='N', 
+            particle_type='N', particle_name='N',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='C', particle_name='CB', 
+            particle_type='C', particle_name='CB',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='O', particle_name='O', 
+            particle_type='O', particle_name='O',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='O', particle_name='O', 
+            particle_type='O', particle_name='O',
             molecule_id=2, molecule_type='OHO', chain_id='W'
         ))
         self.particles.append(Particle(
-            particle_type='H', particle_name='H', 
+            particle_type='H', particle_name='H',
             molecule_id=2, molecule_type='OHO', chain_id='W'
         ))
         self.particles.append(Particle(
-            particle_type='H', particle_name='H', 
+            particle_type='H', particle_name='H',
             molecule_id=2, molecule_type='OHO', chain_id='W'
         ))
         num_particles = len(self.particles)
         self.topology = Topology()
         self.topology.add_particles(self.particles)
-        self.ensemble = Ensemble(self.topology)
-        self.ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
+        self.ensemble = Ensemble(self.topology, np.diag(np.ones(3)*100))
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         positions = np.array(list(range(num_particles)))
         positions = np.vstack([positions, positions, positions]).T
@@ -91,7 +91,8 @@ class TestPDBDumper:
         pass
 
     def test_exceptions(self):
-        pass
+        with pytest.raises(FileFormatError):
+            PDBDumper('test.pd', 1)
 
     def test_dump(self):
         dumper = PDBDumper(self.file_path, 1)

--- a/mdpy/test/test_simulation.py
+++ b/mdpy/test/test_simulation.py
@@ -11,64 +11,63 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest
 import numpy as np
-from ..core import Particle, Topology
-from ..ensemble import Ensemble
-from ..integrator import Integrator
-from ..simulation import Simulation
-from ..error import *
+from mdpy.core import Particle, Topology
+from mdpy.ensemble import Ensemble
+from mdpy.integrator import Integrator
+from mdpy.simulation import Simulation
+from mdpy.error import *
 
 class TestSimulation:
     def setup(self):
         self.particles = []
         self.particles.append(Particle(
-            particle_type='C', particle_name='CA', 
+            particle_type='C', particle_name='CA',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='N', particle_name='N', 
+            particle_type='N', particle_name='N',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='C', particle_name='CB', 
+            particle_type='C', particle_name='CB',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='O', particle_name='O', 
+            particle_type='O', particle_name='O',
             molecule_id=0, molecule_type='ALA', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='C', particle_name='CA', 
+            particle_type='C', particle_name='CA',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='N', particle_name='N', 
+            particle_type='N', particle_name='N',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='C', particle_name='CB', 
+            particle_type='C', particle_name='CB',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='O', particle_name='O', 
+            particle_type='O', particle_name='O',
             molecule_id=1, molecule_type='LEU', chain_id='A'
         ))
         self.particles.append(Particle(
-            particle_type='O', particle_name='O', 
+            particle_type='O', particle_name='O',
             molecule_id=2, molecule_type='OHO', chain_id='W'
         ))
         self.particles.append(Particle(
-            particle_type='H', particle_name='H', 
+            particle_type='H', particle_name='H',
             molecule_id=2, molecule_type='OHO', chain_id='W'
         ))
         self.particles.append(Particle(
-            particle_type='H', particle_name='H', 
+            particle_type='H', particle_name='H',
             molecule_id=2, molecule_type='OHO', chain_id='W'
         ))
         num_particles = len(self.particles)
         self.topology = Topology()
         self.topology.add_particles(self.particles)
-        self.ensemble = Ensemble(self.topology)
-        self.ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
+        self.ensemble = Ensemble(self.topology, np.diag(np.ones(3)*100))
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         positions = np.array(list(range(num_particles)))
         positions = np.vstack([positions, positions, positions]).T

--- a/mdpy/test/test_state.py
+++ b/mdpy/test/test_state.py
@@ -11,10 +11,10 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 
 import pytest
 import numpy as np
-from .. import SPATIAL_DIM, env
-from ..core import Particle, Topology, State
-from ..error import *
-from ..unit import *
+from mdpy import SPATIAL_DIM, env
+from mdpy.core import Particle, Topology, State
+from mdpy.error import *
+from mdpy.unit import *
 
 class TestState:
     def setup(self):
@@ -33,7 +33,7 @@ class TestState:
         self.topology = Topology()
         self.topology.add_particles(self.particles)
         self.topology.join()
-        self.state = State(self.topology)
+        self.state = State(self.topology, np.diag([300, 300, 300]))
 
     def teardown(self):
         self.particles = None
@@ -54,10 +54,7 @@ class TestState:
             self.state.set_velocities(np.ones([self.num_particles, 4]))
 
         with pytest.raises(PBCPoorDefinedError):
-            self.state.pbc_matrix
-
-        with pytest.raises(PBCPoorDefinedError):
-            self.state.pbc_inv
+            self.state.set_pbc_matrix(np.diag([0, 0, 0]))
 
         with pytest.raises(TypeError):
             self.state.set_positions([1, 2, 3])
@@ -77,7 +74,7 @@ class TestState:
         kinetic_energy = Quantity(0, default_energy_unit)
         for particle in range(self.num_particles):
             kinetic_energy += Quantity(0.5) * (
-                Quantity(self.state._masses[particle], default_mass_unit) * 
+                Quantity(self.state._masses[particle], default_mass_unit) *
                 (Quantity(self.state.velocities[particle, :], default_velocity_unit)**2).sum()
             )
         temperature = kinetic_energy * Quantity(2 / 3 / self.num_particles) / KB

--- a/mdpy/test/test_steepest_descent_minimizer.py
+++ b/mdpy/test/test_steepest_descent_minimizer.py
@@ -10,11 +10,11 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import pytest, os
-import numpy as np 
-from ..io import PDBParser, PSFParser 
-from ..forcefield import CharmmForcefield
-from ..minimizer import SteepestDescentMinimizer
-from ..unit import *
+import numpy as np
+from mdpy.io import PDBParser, PSFParser
+from mdpy.forcefield import CharmmForcefield
+from mdpy.minimizer import SteepestDescentMinimizer
+from mdpy.unit import *
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -37,10 +37,9 @@ class TestSteepestDescentMinimizer:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
-        ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
         ensemble.state.cell_list.set_cutoff_radius(12)
         ensemble.state.set_positions(pdb.positions)
         ensemble.state.set_velocities_to_temperature(300)

--- a/mdpy/test/test_verlet_integrator.py
+++ b/mdpy/test/test_verlet_integrator.py
@@ -10,10 +10,10 @@ copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
 '''
 
 import pytest, os
-import numpy as np 
-from ..io import PDBParser, PSFParser 
-from ..forcefield import CharmmForcefield
-from ..integrator import VerletIntegrator
+import numpy as np
+from mdpy.io import PDBParser, PSFParser
+from mdpy.forcefield import CharmmForcefield
+from mdpy.integrator import VerletIntegrator
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
@@ -36,10 +36,9 @@ class TestVerletIntegrator:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology)
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
-        ensemble.state.set_pbc_matrix(np.diag(np.ones(3)*100))
         ensemble.state.cell_list.set_cutoff_radius(12)
         ensemble.state.set_positions(pdb.positions)
         ensemble.state.set_velocities_to_temperature(300)

--- a/mdpy/utils/__init__.py
+++ b/mdpy/utils/__init__.py
@@ -4,30 +4,30 @@ __email__ = "zhenyuwei99@gmail.com"
 __copyright__ = "Copyright 2021-2021, Southeast University and Zhenyu Wei"
 __license__ = "GPLv3"
 
-from .math import sigmoid
-from .geometry import get_unit_vec, get_norm_vec
-from .geometry import get_bond, get_pbc_bond
-from .geometry import get_angle, get_pbc_angle, get_included_angle 
-from .geometry import get_dihedral, get_pbc_dihedral
-from .geometry import generate_rotation_matrix
-from .pbc import check_pbc_matrix
-from .pbc import wrap_positions, unwrap_vec
-from .check_quantity import check_quantity, check_quantity_value
-from .select import select, check_selection_condition, check_topological_selection_condition, parse_selection_condition
-from .select import SELECTION_SUPPORTED_KEYWORDS
-from .select import SELECTION_SUPPORTED_STERIC_KEYWORDS, SELECTION_SUPPORTED_TOPOLOGICAL_KEYWORDS
+from mdpy.utils.math import sigmoid
+from mdpy.utils.geometry import get_unit_vec, get_norm_vec
+from mdpy.utils.geometry import get_bond, get_pbc_bond
+from mdpy.utils.geometry import get_angle, get_pbc_angle, get_included_angle
+from mdpy.utils.geometry import get_dihedral, get_pbc_dihedral
+from mdpy.utils.geometry import generate_rotation_matrix
+from mdpy.utils.pbc import check_pbc_matrix
+from mdpy.utils.pbc import wrap_positions, unwrap_vec
+from mdpy.utils.check_quantity import check_quantity, check_quantity_value
+from mdpy.utils.select import select, check_selection_condition, check_topological_selection_condition, parse_selection_condition
+from mdpy.utils.select import SELECTION_SUPPORTED_KEYWORDS
+from mdpy.utils.select import SELECTION_SUPPORTED_STERIC_KEYWORDS, SELECTION_SUPPORTED_TOPOLOGICAL_KEYWORDS
 
 __all__ = [
     'sigmoid',
-    'get_unit_vec', 'get_norm_vec', 
-    'get_bond', 'get_pbc_bond', 
-    'get_angle', 'get_pbc_angle', 'get_included_angle', 
+    'get_unit_vec', 'get_norm_vec',
+    'get_bond', 'get_pbc_bond',
+    'get_angle', 'get_pbc_angle', 'get_included_angle',
     'get_dihedral', 'get_pbc_dihedral',
     'generate_rotation_matrix',
     'check_pbc_matrix',
     'wrap_positions', 'unwrap_vec',
     'check_quantity', 'check_quantity_value',
     'select', 'check_selection_condition', 'check_topological_selection_condition', 'parse_selection_condition',
-    'SELECTION_SUPPORTED_KEYWORDS', 'SELECTION_SUPPORTED_STERIC_KEYWORDS', 
+    'SELECTION_SUPPORTED_KEYWORDS', 'SELECTION_SUPPORTED_STERIC_KEYWORDS',
     'SELECTION_SUPPORTED_TOPOLOGICAL_KEYWORDS'
 ]

--- a/mdpy/utils/pbc.py
+++ b/mdpy/utils/pbc.py
@@ -23,8 +23,9 @@ def check_pbc_matrix(pbc_matrix):
         )
     if np.linalg.det(pbc_matrix) == 0:
         raise PBCPoorDefinedError(
-            'PBC of %s is poor defined. Two or more column vectors are linear corellated'
+            'PBC is poor defined. Two or more column vectors are linear corellated'
         )
+    return pbc_matrix
 
 def wrap_positions(positions: np.ndarray, pbc_matrix: np.ndarray, pbc_inv: np.array):
     move_vec = - np.round(np.dot(positions, pbc_inv))


### PR DESCRIPTION
# Bug descriptions
- When wrapping the positions when calling mdpy.core.State.set_positions method, the position is possible to be the exact value of the PBC matrix.
- When calling mdpy.core.CellList.update method to construct cell list, the cell index of this or these particles will beyond the element of the list, throwing error

# Update
- mdpy.core.CellList class
- mdpy.core.State class

- mdpy.Ensemble class
- mdpy.utils.pbc module
- mdpy.Simulation class
- mdpy.forcefield.CharmmForcefield class

# Other updates
- Update mdpy.dumper package for adding file format checking
- Update mdpy.io package for the use of mdpy.utils.check_pbc_matrix
- Update mdpy.core.Trajectory class for the use of mdpy.utils.check_pbc_matrix
- Update related test file