### PR TITLE
Add support for Particle Mesh Ewald

### DIFF
--- a/mdpy/constraint/__init__.py
+++ b/mdpy/constraint/__init__.py
@@ -20,7 +20,7 @@ for i in range(-1, 2):
 
 # Electrostatic
 LONG_RANGE_SOLVER = ['PME', 'PPPM']
-from .electrostatic_constraint import ElectrostaticConstraint
+from .electrostatic_cutoff_constraint import ElectrostaticCutoffConstraint
 
 # Charmm
 from .charmm_bond_constraint import CharmmBondConstraint
@@ -30,7 +30,7 @@ from .charmm_improper_constraint import CharmmImproperConstraint
 from .charmm_nonbonded_constraint import CharmmNonbondedConstraint
 
 __all__ = [
-    'ElectrostaticConstraint',
+    'ElectrostaticCutoffConstraint',
     'CharmmBondConstraint', 'CharmmAngleConstraint',
     'CharmmDihedralConstraint', 'CharmmImproperConstraint',
     'CharmmNonbondedConstraint'

--- a/mdpy/constraint/__init__.py
+++ b/mdpy/constraint/__init__.py
@@ -4,20 +4,7 @@ __copyright__ = "(C)Copyright 2021-present, mdpy organization"
 __license__ = "BSD"
 
 from .constraint import Constraint
-
-# Constants
-import numpy as np
-from mdpy import SPATIAL_DIM, env
 from mdpy.error import *
-
-NUM_NEIGHBOR_CELLS = 27
-NEIGHBOR_CELL_TEMPLATE = np.zeros([NUM_NEIGHBOR_CELLS, SPATIAL_DIM], dtype=env.NUMPY_INT)
-index = 0
-for i in range(-1, 2):
-    for j in range(-1, 2):
-        for k in range(-1, 2):
-            NEIGHBOR_CELL_TEMPLATE[index, :] = [i, j, k]
-            index += 1
 
 # Electrostatic
 LONG_RANGE_SOLVER = ['PME', 'CUTOFF']

--- a/mdpy/constraint/__init__.py
+++ b/mdpy/constraint/__init__.py
@@ -7,7 +7,8 @@ from .constraint import Constraint
 
 # Constants
 import numpy as np
-from .. import SPATIAL_DIM, env
+from mdpy import SPATIAL_DIM, env
+from mdpy.error import *
 
 NUM_NEIGHBOR_CELLS = 27
 NEIGHBOR_CELL_TEMPLATE = np.zeros([NUM_NEIGHBOR_CELLS, SPATIAL_DIM], dtype=env.NUMPY_INT)
@@ -19,8 +20,17 @@ for i in range(-1, 2):
             index += 1
 
 # Electrostatic
-LONG_RANGE_SOLVER = ['PME', 'PPPM']
+LONG_RANGE_SOLVER = ['PME', 'CUTOFF']
+def check_long_range_solver(solver: str):
+    if not solver.upper():
+        raise EnsemblePoorDefinedError(
+            '%s solver is not supported. ' +
+            'Check supported platform with `mdpy.constraint.LONG_RANGE_SOLVER`'
+        )
+    return solver.upper()
+
 from .electrostatic_cutoff_constraint import ElectrostaticCutoffConstraint
+from .electrostatic_pme_constraint import ElectrostaticPMEConstraint
 
 # Charmm
 from .charmm_bond_constraint import CharmmBondConstraint
@@ -30,8 +40,12 @@ from .charmm_improper_constraint import CharmmImproperConstraint
 from .charmm_nonbonded_constraint import CharmmNonbondedConstraint
 
 __all__ = [
+    'check_long_range_solver',
     'ElectrostaticCutoffConstraint',
-    'CharmmBondConstraint', 'CharmmAngleConstraint',
-    'CharmmDihedralConstraint', 'CharmmImproperConstraint',
+    'ElectrostaticPMEConstraint',
+    'CharmmBondConstraint',
+    'CharmmAngleConstraint',
+    'CharmmDihedralConstraint',
+    'CharmmImproperConstraint',
     'CharmmNonbondedConstraint'
 ]

--- a/mdpy/constraint/__init__.py
+++ b/mdpy/constraint/__init__.py
@@ -24,7 +24,7 @@ from .charmm_bond_constraint import CharmmBondConstraint
 from .charmm_angle_constraint import CharmmAngleConstraint
 from .charmm_dihedral_constraint import CharmmDihedralConstraint
 from .charmm_improper_constraint import CharmmImproperConstraint
-from .charmm_nonbonded_constraint import CharmmNonbondedConstraint
+from .charmm_vdw_constraint import CharmmVDWConstraint
 
 __all__ = [
     'check_long_range_solver',
@@ -34,5 +34,5 @@ __all__ = [
     'CharmmAngleConstraint',
     'CharmmDihedralConstraint',
     'CharmmImproperConstraint',
-    'CharmmNonbondedConstraint'
+    'CharmmVDWConstraint'
 ]

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -27,8 +27,9 @@ class CharmmAngleConstraint(Constraint):
     def __repr__(self) -> str:
         return '<mdpy.constraint.CharmmAngleConstraint object>'
 
-    __str__ = __repr__
-
+    def __str__(self) -> str:
+        return 'Angle constraint'
+    
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble
         self._force_id = ensemble.constraints.index(self)

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -29,7 +29,7 @@ class CharmmAngleConstraint(Constraint):
 
     def __str__(self) -> str:
         return 'Angle constraint'
-    
+
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble
         self._force_id = ensemble.constraints.index(self)

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -27,7 +27,8 @@ class CharmmBondConstraint(Constraint):
     def __repr__(self) -> str:
         return '<mdpy.constraint.CharmmBondConstraint object>'
 
-    __str__ = __repr__
+    def __str__(self) -> str:
+        return 'Bond constraint'
 
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -28,7 +28,8 @@ class CharmmDihedralConstraint(Constraint):
     def __repr__(self) -> str:
         return '<mdpy.constraint.CharmmDihedralConstraint object>'
 
-    __str__ = __repr__
+    def __str__(self) -> str:
+        return 'Dihedral constraint'
 
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble

--- a/mdpy/constraint/charmm_improper_constraint.py
+++ b/mdpy/constraint/charmm_improper_constraint.py
@@ -27,7 +27,8 @@ class CharmmImproperConstraint(Constraint):
     def __repr__(self) -> str:
         return '<mdpy.constraint.CharmmImproperConstraint object>'
 
-    __str__ = __repr__
+    def __str__(self) -> str:
+        return 'Improper constraint'
 
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble

--- a/mdpy/constraint/charmm_nonbonded_constraint.py
+++ b/mdpy/constraint/charmm_nonbonded_constraint.py
@@ -21,29 +21,23 @@ from mdpy.unit import *
 class CharmmNonbondedConstraint(Constraint):
     def __init__(self, parameters, cutoff_radius=12, force_id: int = 0, force_group: int = 0) -> None:
         super().__init__(parameters, force_id=force_id, force_group=force_group)
+        # Attributes
         self._cutoff_radius = check_quantity_value(cutoff_radius, default_length_unit)
+        self._device_cutoff_radius = cuda.to_device(np.array([self._cutoff_radius]))
         self._parameters_list = []
-        self._neighbor_list = []
-        self._neighbor_distance = []
-        self._num_nonbonded_pairs = 0
-        if env.platform == 'CPU':
-            self._kernel = nb.njit((
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1],
-                env.NUMBA_FLOAT, env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, ::1],
-                env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, :, :, ::1], env.NUMBA_INT[::1], env.NUMBA_INT[:, ::1]
-            ))(self.cpu_kernel)
-        elif env.platform == 'CUDA':
-            self._kernel = cuda.jit(nb.void(
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1],
-                env.NUMBA_FLOAT[::1], env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, ::1],
-                env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, :, :, ::1], env.NUMBA_INT[::1], env.NUMBA_INT[:, ::1],
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1]
-            ))(self.cuda_kernel)
+        # Kernel
+        self._update = cuda.jit(nb.void(
+            env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1],
+            env.NUMBA_FLOAT[::1], env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, ::1],
+            env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, :, :, ::1], env.NUMBA_INT[::1], env.NUMBA_INT[:, ::1],
+            env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1]
+        ))(self._update_kernel)
 
     def __repr__(self) -> str:
         return '<mdpy.constraint.CharmmNonbondedConstraint object>'
 
-    __str__ = __repr__
+    def __str__(self) -> str:
+        return 'Nonbonded constraint'
 
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble
@@ -58,64 +52,19 @@ class CharmmNonbondedConstraint(Constraint):
                 epsilon, sigma, epsilon14, sigma14 = param
                 self._parameters_list.append([epsilon, sigma, epsilon14, sigma14])
         self._parameters_list = np.vstack(self._parameters_list).astype(env.NUMPY_FLOAT)
-        if env.platform == 'CUDA':
-            self._device_parameters_list = cuda.to_device(self._parameters_list)
+        self._device_parameters_list = cuda.to_device(self._parameters_list)
+        self._device_pbc_matrix = cuda.to_device(self._parent_ensemble.state.pbc_matrix)
+        self._device_bonded_particles = cuda.to_device(self._parent_ensemble.topology.bonded_particles)
+        self._device_scaling_particles = cuda.to_device(self._parent_ensemble.topology.scaling_particles)
 
     @staticmethod
-    def cpu_kernel(
-        positions, parameters, pbc_matrix, pbc_inv, cutoff_radius,
-        bonded_particles, scaling_particles,
-        particle_cell_index, cell_list, num_cell_vec, neighbor_cell_template,
-    ):
-        forces = np.zeros_like(positions)
-        potential_energy = forces[0, 0]
-        int_type = particle_cell_index.dtype
-        num_particles = positions.shape[0]
-        num_neighbor_cells = neighbor_cell_template.shape[0]
-        for id1 in range(num_particles):
-            cur_bonded_particles = bonded_particles[id1][bonded_particles[id1] != -1]
-            cur_scaling_particles = scaling_particles[id1][scaling_particles[id1] != -1]
-            neighbor_cell = neighbor_cell_template + particle_cell_index[id1]
-            wrap_flag = (neighbor_cell >= num_cell_vec).astype(int_type)
-            neighbor_cell -= wrap_flag * num_cell_vec
-            for cell_index in range(num_neighbor_cells):
-                i, j, k = neighbor_cell[cell_index, :]
-                neighbors = [i for i in cell_list[i, j, k, :] if not i in cur_bonded_particles and i != -1 and i != id1]
-                for id2 in neighbors:
-                    force_vec = unwrap_vec(
-                        positions[id2] - positions[id1],
-                        pbc_matrix, pbc_inv
-                    )
-                    r = np.linalg.norm(force_vec)
-                    if r <= cutoff_radius:
-                        force_vec /= r
-                        if id2 in cur_scaling_particles:
-                            epsilon1, sigma1 = parameters[id1, 2:]
-                            epsilon2, sigma2 = parameters[id2, 2:]
-                        else:
-                            epsilon1, sigma1 = parameters[id1, :2]
-                            epsilon2, sigma2 = parameters[id2, :2]
-                        epsilon, sigma = (
-                            np.sqrt(epsilon1 * epsilon2),
-                            (sigma1 + sigma2) / 2
-                        )
-                        scaled_r = sigma / r
-                        force_val = - (2 * scaled_r**12 - scaled_r**6) / r * epsilon * 24 # Sequence for small number divide small number
-                        force = force_vec * force_val / 2
-                        forces[id1, :] += force
-                        forces[id2, :] -= force
-                        potential_energy += 4 * epsilon * (scaled_r**12 - scaled_r**6) / 2
-        return forces, potential_energy
-
-    @staticmethod
-    def cuda_kernel(
+    def _update_kernel(
         positions, parameters, pbc_matrix, cutoff_radius,
         bonded_particles, scaling_particles,
         particle_cell_index, cell_list, num_cell_vec, neighbor_cell_template,
         forces, potential_energy
     ):
-        thread_x = cuda.blockIdx.x * cuda.blockDim.x + cuda.threadIdx.x
-        thread_y = cuda.blockIdx.y * cuda.blockDim.y + cuda.threadIdx.y
+        thread_x, thread_y = cuda.grid(2)
         num_particles_per_cell = cell_list.shape[3]
         num_particles = positions.shape[0]
 
@@ -133,14 +82,14 @@ class CharmmNonbondedConstraint(Constraint):
         z = particle_cell_index[id1, 2] + neighbor_cell_template[cell_id, 2]
         z = z - num_cell_vec[2] if z >= num_cell_vec[2] else z
         id2 = cell_list[x, y, z, cell_particle_id]
-        if id1 == id2:
+        if id1 == id2: # self-self term
             return None
-        if id2 == -1:
+        if id2 == -1: # self-padding term
             return None
         for i in bonded_particles[id1, :]:
-            if i == -1:
+            if i == -1: # padding of bonded particle
                 break
-            elif id2 == i:
+            elif id2 == i: # self-bonded particle term
                 return None
         x = (positions[id2, 0] - positions[id1, 0]) / pbc_matrix[0, 0]
         x = (x - round(x)) * pbc_matrix[0, 0]
@@ -182,49 +131,31 @@ class CharmmNonbondedConstraint(Constraint):
 
     def update(self):
         self._check_bound_state()
-        if env.platform == 'CPU':
-                self._forces, self._potential_energy = self._kernel(
-                self._parent_ensemble.state.positions, self._parameters_list,
-                *self._parent_ensemble.state.pbc_info, self._cutoff_radius,
-                self._parent_ensemble.topology.bonded_particles,
-                self._parent_ensemble.topology.scaling_particles,
-                self._parent_ensemble.state.cell_list.particle_cell_index,
-                self._parent_ensemble.state.cell_list.cell_list,
-                self._parent_ensemble.state.cell_list.num_cell_vec,
-                NEIGHBOR_CELL_TEMPLATE.astype(env.NUMPY_INT)
-            )
-        elif env.platform == 'CUDA':
-            self._forces = np.zeros_like(self._parent_ensemble.state.positions)
-            self._potential_energy = np.zeros([1], dtype=env.NUMPY_FLOAT)
-            d_positions = cuda.to_device(self._parent_ensemble.state.positions)
-            d_pbc_martix = cuda.to_device(self._parent_ensemble.state.pbc_matrix)
-            d_cutoff_radius = cuda.to_device(np.array([self._cutoff_radius], dtype=env.NUMPY_FLOAT))
-            d_bonded_particles = cuda.to_device(self._parent_ensemble.topology.bonded_particles)
-            d_scaling_particles = cuda.to_device(self._parent_ensemble.topology.scaling_particles)
-            d_particle_cell_index = cuda.to_device(self._parent_ensemble.state.cell_list.particle_cell_index)
-            d_cell_list = cuda.to_device(self._parent_ensemble.state.cell_list.cell_list)
-            d_num_cell_vec = cuda.to_device(self._parent_ensemble.state.cell_list.num_cell_vec)
-            d_neighbor_cell_template = cuda.to_device(NEIGHBOR_CELL_TEMPLATE.astype(env.NUMPY_INT))
-            d_forces = cuda.to_device(self._forces)
-            d_potential_energy = cuda.to_device(self._potential_energy)
-            thread_per_block = (8, 8)
-            block_per_grid_x = int(np.ceil(
-                self._parent_ensemble.topology.num_particles / thread_per_block[0]
-            ))
-            block_per_grid_y = int(np.ceil(
-                self._parent_ensemble.state.cell_list.num_particles_per_cell * NUM_NEIGHBOR_CELLS / thread_per_block[1]
-            ))
-            block_per_grid = (block_per_grid_x, block_per_grid_y)
-            self._kernel[block_per_grid, thread_per_block](
-                d_positions, self._device_parameters_list, d_pbc_martix, d_cutoff_radius,
-                d_bonded_particles, d_scaling_particles,
-                d_particle_cell_index, d_cell_list, d_num_cell_vec,
-                d_neighbor_cell_template,
-                d_forces, d_potential_energy
-            )
-            self._forces = d_forces.copy_to_host()
-            self._potential_energy = d_potential_energy.copy_to_host()[0]
-
-    @property
-    def num_nonbonded_pairs(self):
-        return self._num_nonbonded_pairs
+        self._forces = np.zeros_like(self._parent_ensemble.state.positions)
+        self._potential_energy = np.zeros([1], dtype=env.NUMPY_FLOAT)
+        # Device
+        device_positions = cuda.to_device(self._parent_ensemble.state.positions)
+        device_particle_cell_index = cuda.to_device(self._parent_ensemble.state.cell_list.particle_cell_index)
+        device_cell_list = cuda.to_device(self._parent_ensemble.state.cell_list.cell_list)
+        device_num_cell_vec = cuda.to_device(self._parent_ensemble.state.cell_list.num_cell_vec)
+        device_neighbor_cell_template = cuda.to_device(NEIGHBOR_CELL_TEMPLATE.astype(env.NUMPY_INT))
+        device_forces = cuda.to_device(self._forces)
+        device_potential_energy = cuda.to_device(self._potential_energy)
+        thread_per_block = (8, 8)
+        block_per_grid_x = int(np.ceil(
+            self._parent_ensemble.topology.num_particles / thread_per_block[0]
+        ))
+        block_per_grid_y = int(np.ceil(
+            self._parent_ensemble.state.cell_list.num_particles_per_cell * NUM_NEIGHBOR_CELLS / thread_per_block[1]
+        ))
+        block_per_grid = (block_per_grid_x, block_per_grid_y)
+        self._update[block_per_grid, thread_per_block](
+            device_positions, self._device_parameters_list,
+            self._device_pbc_matrix, self._device_cutoff_radius,
+            self._device_bonded_particles, self._device_scaling_particles,
+            device_particle_cell_index, device_cell_list, device_num_cell_vec,
+            device_neighbor_cell_template,
+            device_forces, device_potential_energy
+        )
+        self._forces = device_forces.copy_to_host()
+        self._potential_energy = device_potential_energy.copy_to_host()[0]

--- a/mdpy/constraint/charmm_vdw_constraint.py
+++ b/mdpy/constraint/charmm_vdw_constraint.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 '''
-file : charmm_nonbonded_constraint.py
+file : charmm_vdw_constraint.py
 created time : 2021/10/12
 author : Zhenyu Wei
 copyright : (C)Copyright 2021-present, mdpy organization
@@ -13,12 +13,12 @@ import numba as nb
 from numba import cuda
 from operator import floordiv
 from mdpy import env
-from mdpy.core import Ensemble
-from mdpy.constraint import Constraint, NUM_NEIGHBOR_CELLS, NEIGHBOR_CELL_TEMPLATE
+from mdpy.core import Ensemble, NUM_NEIGHBOR_CELLS, NEIGHBOR_CELL_TEMPLATE
+from mdpy.constraint import Constraint
 from mdpy.utils import *
 from mdpy.unit import *
 
-class CharmmNonbondedConstraint(Constraint):
+class CharmmVDWConstraint(Constraint):
     def __init__(self, parameters, cutoff_radius=12, force_id: int = 0, force_group: int = 0) -> None:
         super().__init__(parameters, force_id=force_id, force_group=force_group)
         # Attributes
@@ -34,10 +34,10 @@ class CharmmNonbondedConstraint(Constraint):
         ))(self._update_kernel)
 
     def __repr__(self) -> str:
-        return '<mdpy.constraint.CharmmNonbondedConstraint object>'
+        return '<mdpy.constraint.CharmmVDWConstraint object>'
 
     def __str__(self) -> str:
-        return 'Nonbonded constraint'
+        return 'VDW constraint'
 
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -18,24 +18,19 @@ from mdpy.constraint import Constraint, NUM_NEIGHBOR_CELLS, NEIGHBOR_CELL_TEMPLA
 from mdpy.utils import *
 from mdpy.unit import *
 
-epsilon0 = EPSILON0.value
-
 class ElectrostaticCutoffConstraint(Constraint):
     def __init__(self, parameters=None, force_id: int = 0, force_group: int = 0) -> None:
         super().__init__(parameters, force_id=force_id, force_group=force_group)
+        # Attributes
         self._int_parameters = []
         self._float_parameters = []
-        if env.platform == 'CPU':
-            self._kernel = nb.njit((
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_INT[:, ::1],
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1]
-            ))(self.cpu_kernel)
-        elif env.platform == 'CUDA':
-            self._kernel = cuda.jit(nb.void(
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1], env.NUMBA_INT[:, ::1], env.NUMBA_FLOAT[:, ::1],
-                env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, :, :, ::1], env.NUMBA_INT[::1], env.NUMBA_INT[:, ::1],
-                env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1]
-            ))(self.cuda_kernel)
+        self._device_k = cuda.to_device(np.array([4 * np.pi * EPSILON0.value], dtype=env.NUMPY_FLOAT))
+        # Kernel
+        self._update = cuda.jit(nb.void(
+            env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1], env.NUMBA_INT[:, ::1], env.NUMBA_FLOAT[:, ::1],
+            env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, :, :, ::1], env.NUMBA_INT[::1], env.NUMBA_INT[:, ::1],
+            env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1]
+        ))(self._update_kernel)
 
     def __repr__(self) -> str:
         return '<mdpy.constraint.ElectrostaticCutoffConstraint object>'
@@ -46,47 +41,19 @@ class ElectrostaticCutoffConstraint(Constraint):
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble
         self._force_id = ensemble.constraints.index(self)
-        if env.platform == 'CUDA':
-            self._device_charges = cuda.to_device(self._parent_ensemble.topology.charges)
-            self._device_k = cuda.to_device(np.array([4 * np.pi * epsilon0], dtype=env.NUMPY_FLOAT))
+        self._device_charges = cuda.to_device(self._parent_ensemble.topology.charges)
+        self._device_pbc_matrix = cuda.to_device(self._parent_ensemble.state.pbc_matrix)
+        self._device_cutoff_radius = cuda.to_device(np.array([self._cutoff_radius], dtype=env.NUMPY_FLOAT))
+        self._device_bonded_particles = cuda.to_device(self._parent_ensemble.topology.bonded_particles)
+        self._device_scaling_particles = cuda.to_device(self._parent_ensemble.topology.scaling_particles)
 
     @staticmethod
-    def cpu_kernel(
-        positions, charges, bonded_particles,
-        pbc_matrix, pbc_inv
-    ):
-        forces = np.zeros_like(positions)
-        potential_energy = forces[0, 0]
-        num_particles = positions.shape[0]
-        k = 4 * np.pi * epsilon0
-        for id1 in range(num_particles):
-            cur_bonded_particles = bonded_particles[id1, :][bonded_particles[id1, :] != -1]
-            for id2 in range(id1+1, num_particles):
-                if not id2 in cur_bonded_particles:
-                    e1 = charges[id1, 0]
-                    e2 = charges[id2, 0]
-                    force_vec = unwrap_vec(
-                        positions[id2, :] - positions[id1, :],
-                        pbc_matrix, pbc_inv
-                    )
-                    dist = np.linalg.norm(force_vec)
-                    force_vec /= dist
-                    force_val = - e1 * e2 / k / dist**2
-                    force = force_vec * force_val
-                    forces[id1, :] += force
-                    forces[id2, :] -= force
-                    # Potential energy
-                    potential_energy += e1 * e2 / k / dist
-        return forces, potential_energy
-
-    @staticmethod
-    def cuda_kernel(
+    def _update_kernel(
         positions, charges, k, bonded_particles, pbc_matrix,
         particle_cell_index, cell_list, num_cell_vec, neighbor_cell_template,
         forces, potential_energy
     ):
-        thread_x = cuda.blockIdx.x * cuda.blockDim.x + cuda.threadIdx.x
-        thread_y = cuda.blockIdx.y * cuda.blockDim.y + cuda.threadIdx.y
+        thread_x, thread_y = cuda.grid(2)
         num_particles_per_cell = cell_list.shape[3]
         num_particles = positions.shape[0]
         id1 = thread_x
@@ -136,40 +103,29 @@ class ElectrostaticCutoffConstraint(Constraint):
         cuda.atomic.add(potential_energy, 0, energy)
 
     def update(self):
-        self._check_bound_state()
-        if env.platform == 'CPU':
-            self._forces, self._potential_energy = self._kernel(
-                self._parent_ensemble.state.positions,
-                self._parent_ensemble.topology.charges,
-                self._parent_ensemble.topology.bonded_particles,
-                *self._parent_ensemble.state.pbc_info
-            )
-        elif env.platform == 'CUDA':
-            self._forces = np.zeros_like(self._parent_ensemble.state.positions)
-            self._potential_energy = np.zeros([1], dtype=env.NUMPY_FLOAT)
-            d_positions = cuda.to_device(self._parent_ensemble.state.positions)
-            d_bonded_particles = cuda.to_device(self._parent_ensemble.topology.bonded_particles)
-            d_pbc_matrix = cuda.to_device(self._parent_ensemble.state.pbc_matrix)
-            d_particle_cell_index = cuda.to_device(self._parent_ensemble.state.cell_list.particle_cell_index)
-            d_cell_list = cuda.to_device(self._parent_ensemble.state.cell_list.cell_list)
-            d_num_cell_vec = cuda.to_device(self._parent_ensemble.state.cell_list.num_cell_vec)
-            d_neighbor_cell_template = cuda.to_device(NEIGHBOR_CELL_TEMPLATE.astype(env.NUMPY_INT))
-            d_forces = cuda.to_device(self._forces)
-            d_potential_energy = cuda.to_device(self._potential_energy)
-            thread_per_block = (8, 8)
-            block_per_grid_x = int(np.ceil(
-                self._parent_ensemble.topology.num_particles / thread_per_block[0]
-            ))
-            block_per_grid_y = int(np.ceil(
-                self._parent_ensemble.state.cell_list.num_particles_per_cell * NUM_NEIGHBOR_CELLS / thread_per_block[1]
-            ))
-            block_per_grid = (block_per_grid_x, block_per_grid_y)
-            self._kernel[block_per_grid, thread_per_block](
-                d_positions, self._device_charges, self._device_k,
-                d_bonded_particles, d_pbc_matrix,
-                d_particle_cell_index, d_cell_list,
-                d_num_cell_vec, d_neighbor_cell_template,
-                d_forces, d_potential_energy
-            )
-            self._forces = d_forces.copy_to_host()
-            self._potential_energy = d_potential_energy.copy_to_host()[0]
+        self._forces = np.zeros_like(self._parent_ensemble.state.positions)
+        self._potential_energy = np.zeros([1], dtype=env.NUMPY_FLOAT)
+        device_positions = cuda.to_device(self._parent_ensemble.state.positions)
+        device_particle_cell_index = cuda.to_device(self._parent_ensemble.state.cell_list.particle_cell_index)
+        device_cell_list = cuda.to_device(self._parent_ensemble.state.cell_list.cell_list)
+        device_num_cell_vec = cuda.to_device(self._parent_ensemble.state.cell_list.num_cell_vec)
+        device_neighbor_cell_template = cuda.to_device(NEIGHBOR_CELL_TEMPLATE.astype(env.NUMPY_INT))
+        device_forces = cuda.to_device(self._forces)
+        device_potential_energy = cuda.to_device(self._potential_energy)
+        thread_per_block = (8, 8)
+        block_per_grid_x = int(np.ceil(
+            self._parent_ensemble.topology.num_particles / thread_per_block[0]
+        ))
+        block_per_grid_y = int(np.ceil(
+            self._parent_ensemble.state.cell_list.num_particles_per_cell * NUM_NEIGHBOR_CELLS / thread_per_block[1]
+        ))
+        block_per_grid = (block_per_grid_x, block_per_grid_y)
+        self._update[block_per_grid, thread_per_block](
+            device_positions, self._device_charges, self._device_k,
+            self._device_bonded_particles, self._device_pbc_matrix,
+            device_particle_cell_index, device_cell_list,
+            device_num_cell_vec, device_neighbor_cell_template,
+            device_forces, device_potential_energy
+        )
+        self._forces = device_forces.copy_to_host()
+        self._potential_energy = device_potential_energy.copy_to_host()[0]

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -40,7 +40,8 @@ class ElectrostaticCutoffConstraint(Constraint):
     def __repr__(self) -> str:
         return '<mdpy.constraint.ElectrostaticCutoffConstraint object>'
 
-    __str__ = __repr__
+    def __str__(self) -> str:
+        return 'Cutoff electrostatic constraint'
 
     def bind_ensemble(self, ensemble: Ensemble):
         self._parent_ensemble = ensemble

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 '''
-file : electrostatic_constraint.py
+file : electrostatic_cutoff_constraint.py
 created time : 2021/10/13
 author : Zhenyu Wei
 copyright : (C)Copyright 2021-present, mdpy organization
@@ -20,7 +20,7 @@ from mdpy.unit import *
 
 epsilon0 = EPSILON0.value
 
-class ElectrostaticConstraint(Constraint):
+class ElectrostaticCutoffConstraint(Constraint):
     def __init__(self, parameters=None, force_id: int = 0, force_group: int = 0) -> None:
         super().__init__(parameters, force_id=force_id, force_group=force_group)
         self._int_parameters = []
@@ -38,7 +38,7 @@ class ElectrostaticConstraint(Constraint):
             ))(self.cuda_kernel)
 
     def __repr__(self) -> str:
-        return '<mdpy.constraint.ElectrostaticConstraint object>'
+        return '<mdpy.constraint.ElectrostaticCutoffConstraint object>'
 
     __str__ = __repr__
 

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -13,8 +13,8 @@ import numba as nb
 from numba import cuda
 from operator import floordiv
 from mdpy import env
-from mdpy.core import Ensemble
-from mdpy.constraint import Constraint, NUM_NEIGHBOR_CELLS, NEIGHBOR_CELL_TEMPLATE
+from mdpy.core import Ensemble, NUM_NEIGHBOR_CELLS, NEIGHBOR_CELL_TEMPLATE
+from mdpy.constraint import Constraint
 from mdpy.utils import *
 from mdpy.unit import *
 

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+'''
+file : electrostatic_pme_constraint.py
+created time : 2022/04/07
+author : Zhenyu Wei
+version : 1.0
+contact : zhenyuwei99@gmail.com
+copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
+'''
+
+import time
+import math
+import numpy as np
+import numba as nb
+import scipy.fft as fft
+from numba import cuda
+from operator import floordiv
+from mdpy import env, SPATIAL_DIM
+from mdpy.core import Ensemble
+from mdpy.constraint import Constraint, NUM_NEIGHBOR_CELLS, NEIGHBOR_CELL_TEMPLATE
+from mdpy.utils import *
+from mdpy.unit import *
+from mdpy.error import *
+
+PME_ORDER = 4
+
+def bspline(x, order):
+    if order == 2:
+        return 1 - np.abs(x-1) if x >= 0 and x <= 2 else 0
+    else:
+        return (
+            x * bspline(x, order-1) / (order - 1) +
+            (order - x) * bspline(x-1, order-1) / (order-1)
+        )
+
+def gamma_sum(m, num_grids, order):
+    x = np.pi * m / num_grids
+    k = np.arange(1, 51)
+    res = 1
+    res += ((x / (x + np.pi*k))**order).sum()
+    res += ((x / (x - np.pi*k))**order).sum()
+    return res
+
+class ElectrostaticPMEConstraint(Constraint):
+    def __init__(
+        self, cutoff_radius=8, direct_sum_energy_tolerance=1e-5,
+        force_id: int = 0, force_group: int = 0
+    ) -> None:
+        super().__init__(None, force_id, force_group)
+        self._cutoff_radius = check_quantity_value(cutoff_radius, default_length_unit)
+        self._device_cutoff_radius = cuda.to_device(np.array([self._cutoff_radius]))
+        self._direct_sum_energy_tolerance = direct_sum_energy_tolerance
+        self._ewald_coefficient = self._get_ewald_coefficient()
+        self._device_ewald_coefficient = cuda.to_device(
+            np.array([self._ewald_coefficient], dtype=env.NUMPY_FLOAT)
+        )
+        self._k = 4 * np.pi * EPSILON0.value
+        self._device_k = cuda.to_device(np.array([4 * np.pi * EPSILON0.value], dtype=env.NUMPY_FLOAT))
+        # Attribute
+        self._charges = None
+        self._grid_size = None
+        self._b_grid = None
+        self._c_grid = None
+        # Kernel
+        self._update_direct_part = cuda.jit(nb.void(
+            env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1], # position, charges
+            env.NUMBA_FLOAT[::1], env.NUMBA_FLOAT[::1], # k, ewald_coefficient
+            env.NUMBA_FLOAT[::1], env.NUMBA_FLOAT[:, ::1], # cutoff_radius, pbc_matrix
+            env.NUMBA_INT[:, ::1], # bonded_particles
+            env.NUMBA_INT[:, ::1], env.NUMBA_INT[:, :, :, ::1], # particle_cell_index, cell_list
+            env.NUMBA_INT[::1], env.NUMBA_INT[:, ::1], # num_cell_vec, neighbor_cell_template
+            env.NUMBA_FLOAT[:, ::1], env.NUMBA_FLOAT[::1] # force, potential_energy
+        ))(self._update_direct_part_kernel)
+        # self._bspline = nb.njit((
+        #     env.NUMBA_INT, env.NUMBA_FLOAT[:, ::1], # num_particles, positions
+        #     env.NUMBA_INT[::1], env.NUMBA_FLOAT[:, ::1] # grid_size, pbc_inv
+        # ))(self._bspline_kernel)
+        self._update_bspline = self._update_bspline_kernel
+        self._update_charge_map = cuda.jit(nb.void(
+            env.NUMBA_INT[::1], # num_particles
+            env.NUMBA_FLOAT[:, :, ::1], env.NUMBA_INT[:, :, ::1], # spline_coefficient, grid_map
+            env.NUMBA_FLOAT[::1], env.NUMBA_FLOAT[:, :, ::1] # charges, charge_map
+        ))(self._update_charge_map_kernel)
+        self._update_reciprocal_energy = self._update_reciprocal_energy_kernel
+        self._update_reciprocal_force = cuda.jit(nb.void(
+            env.NUMBA_INT[::1], # num_particles
+            env.NUMBA_FLOAT[:, :, ::1], # spline_coefficient
+            env.NUMBA_FLOAT[:, :, ::1], # spline_derivative_+coefficient
+            env.NUMBA_INT[:, :, ::1], env.NUMBA_FLOAT[:, :, ::1], # grid_map, energy_map
+            env.NUMBA_FLOAT[::1], env.NUMBA_FLOAT[:, ::1] # charges, force
+        ))(self._update_reciprocal_force_kernel)
+
+    def _get_ewald_coefficient(self):
+        '''
+        Using Newton interation solve ewald coefficient
+
+        Essentially, the Ewald coefficient is mathematical shorthand for 1/2s, where s is the width of the Gaussian used to smooth out charges on the grid.  That width is chosen such that, at the direct space interaction `cutoff_radius`, the interaction of two Gaussian-smoothed charges and the interaction of two point charges are identical to a precision of `direct_sum_energy_tolerance`, which mean the interaction between these 4 charge site are small enough, proving truncation yielding no big error
+
+        f(alpha) = erfc(alpha*cutoff_radius) / cutoff_radius - direct_sum_energy_tolerance
+        f'(alpha) = - 2/sqrt(pi) * exp[-(alpha*cutoff_radius)^2]
+
+        alpha_new = alpha_old - f(alpha_old) / f'(alpha_old)
+        '''
+        alpha = 0.1
+        sqrt_pi = np.sqrt(np.pi)
+        while True:
+            f = (
+                math.erfc(alpha*self._cutoff_radius)/self._cutoff_radius -
+                self._direct_sum_energy_tolerance
+            )
+            df = - 2 * np.exp(-(alpha*self._cutoff_radius)**2) / sqrt_pi
+            d_alpha = f / df
+            if np.abs(d_alpha/alpha) < 1e-5:
+                break
+            alpha -= d_alpha
+        return alpha
+
+    def _get_grid_size(self):
+        '''
+        Set the grid size with spacing around 0.75 angstrom and power to 2 for better fft performance
+        '''
+        pbc_diag = np.diag(Quantity(
+            self._parent_ensemble.state.pbc_matrix, default_length_unit
+        ).convert_to(angstrom).value)
+        grid_size = np.ceil(pbc_diag/2) * 2
+        return grid_size.astype(env.NUMPY_INT)
+
+    def _get_b_grid(self):
+        b_grid = np.zeros(self._grid_size)
+        b_factor = []
+        for i in range(SPATIAL_DIM):
+            num_grids = self._grid_size[i]
+            half_num_grids = num_grids // 2
+            # denominator
+            # Calculate the abs of denminator directly
+            denominator = np.zeros([num_grids])
+            prefactor = np.zeros([3])
+            prefactor[0] = bspline(1, PME_ORDER)
+            prefactor[1] = bspline(2, PME_ORDER)
+            prefactor[2] = bspline(3, PME_ORDER)
+            k_vec = np.arange(3)
+            for m in np.arange(num_grids):
+                factor = 2 * np.pi * m * k_vec / num_grids
+                sin_term = (prefactor * np.sin(factor)).sum()
+                cos_term = (prefactor * np.cos(factor)).sum()
+                denominator[m] = sin_term**2 + cos_term**2
+            # Handle small denominator
+            for i in range(num_grids):
+                if denominator[i] <= 1e-7:
+                    if i != 0 and i != num_grids-1:
+                        # Replace with mean value of two neighbor points
+                        denominator[i] = (denominator[i-1] + denominator[i+1]) / 2
+                    else:
+                        # Boundary point set to a very high value, 0 for denominator
+                        denominator[i] = 1e7
+            # nominator
+            nominator = np.zeros([num_grids])
+            for index in range(num_grids):
+                if index >= half_num_grids:
+                    m = index - num_grids
+                else:
+                    m = index
+                if m == 0:
+                    nominator[index] = 1
+                else:
+                    nominator[index] = gamma_sum(m, num_grids, PME_ORDER) / gamma_sum(m, num_grids, 8)
+            b_factor.append(nominator**2/denominator)
+        for i in range(self._grid_size[0]):
+            for j in range(self._grid_size[1]):
+                for k in range(self._grid_size[2]):
+                    b_grid[i, j, k] = (
+                        b_factor[0][i] * b_factor[1][j] * b_factor[2][k]
+                    )
+        return b_grid
+
+    def _get_c_grid(self):
+        c_grid = np.zeros(self._grid_size)
+        freqency_factor, exp_factor = [], []
+        for i in range(SPATIAL_DIM):
+            num_grids = self._grid_size[i]
+            half_num_grids = num_grids // 2
+            m_vec = np.arange(num_grids)
+            m_vec[m_vec > half_num_grids] -= num_grids
+            m_vec = m_vec / num_grids
+            exp_vec = np.exp(-(np.pi*m_vec/self._ewald_coefficient)**2)
+            freqency_factor.append(m_vec)
+            exp_factor.append(exp_vec)
+        for i in range(self._grid_size[0]):
+            for j in range(self._grid_size[1]):
+                for k in range(self._grid_size[2]):
+                    if i == 0 and j == 0 and k == 0:
+                        continue
+                    c_grid[i, j, k] = (
+                        exp_factor[0][i] * exp_factor[1][j] * exp_factor[2][k]
+                    )
+                    c_grid[i, j, k] = c_grid[i, j, k] / (
+                        freqency_factor[0][i]**2 +
+                        freqency_factor[1][j]**2 +
+                        freqency_factor[2][k]**2
+                    )
+        c_grid = c_grid / ( # / pi V
+            np.prod(np.diagonal(self._parent_ensemble.state.pbc_matrix)) /
+            self._num_grids_total * np.pi
+        )
+        return c_grid
+
+    def bind_ensemble(self, ensemble: Ensemble):
+        self._parent_ensemble = ensemble
+        self._force_id = ensemble.constraints.index(self)
+        self._charges = self._parent_ensemble.topology.charges[:, 0]
+        if self._charges.sum() != 0:
+            raise EnsemblePoorDefinedError('mdpy.constraint.ElectrostaticPMEConstraint is bound to a non-neutralized ensemble')
+        # Grid size
+        self._grid_size = self._get_grid_size()
+        self._num_grids_total = np.prod(self._grid_size)
+        # create b grid
+        self._b_grid = self._get_b_grid()
+        # create c grid
+        self._c_grid = self._get_c_grid()
+        # device attributes
+        self._device_charges = cuda.to_device(self._charges)
+        self._device_pbc_matrix = cuda.to_device(self._parent_ensemble.state.pbc_matrix)
+        self._device_cutoff_radius = cuda.to_device(np.array([self._cutoff_radius]))
+        self._device_bonded_particles = cuda.to_device(self._parent_ensemble.topology.bonded_particles)
+        self._device_b_grid = cuda.to_device(self._b_grid)
+        self._device_c_grid = cuda.to_device(self._c_grid)
+
+    @staticmethod
+    def _update_direct_part_kernel(
+        positions, charges,
+        k, ewald_coefficient,
+        cutoff_radius, pbc_matrix,
+        bonded_particles,
+        particle_cell_index, cell_list,
+        num_cell_vec, neighbor_cell_template,
+        forces, potential_energy
+    ):
+        thread_x, thread_y = cuda.grid(2)
+        k, ewald_coefficient, cutoff_radius = k[0], ewald_coefficient[0], cutoff_radius[0]
+        num_particles_per_cell = cell_list.shape[3]
+        num_particles = positions.shape[0]
+        id1 = thread_x
+        if id1 >= num_particles:
+            return None
+        cell_id = floordiv(thread_y, num_particles_per_cell)
+        cell_particle_id = thread_y % num_particles_per_cell
+        if cell_id >= NUM_NEIGHBOR_CELLS:
+            return None
+        x = particle_cell_index[id1, 0] + neighbor_cell_template[cell_id, 0]
+        x = x - num_cell_vec[0] if x >= num_cell_vec[0] else x
+        y = particle_cell_index[id1, 1] + neighbor_cell_template[cell_id, 1]
+        y = y - num_cell_vec[1] if y >= num_cell_vec[1] else y
+        z = particle_cell_index[id1, 2] + neighbor_cell_template[cell_id, 2]
+        z = z - num_cell_vec[2] if z >= num_cell_vec[2] else z
+        id2 = cell_list[x, y, z, cell_particle_id]
+        if id1 == id2:
+            return None
+        if id2 == -1:
+            return None
+        for i in bonded_particles[id1, :]:
+            if i == -1:
+                break
+            if id2 == i:
+                return None
+        x = (positions[id2, 0] - positions[id1, 0]) / pbc_matrix[0, 0]
+        x = (x - round(x)) * pbc_matrix[0, 0]
+        y = (positions[id2, 1] - positions[id1, 1]) / pbc_matrix[1, 1]
+        y = (y - round(y)) * pbc_matrix[1, 1]
+        z = (positions[id2, 2] - positions[id1, 2]) / pbc_matrix[2, 2]
+        z = (z - round(z)) * pbc_matrix[2, 2]
+        r = math.sqrt(x**2 + y**2 + z**2)
+        if r <= cutoff_radius:
+            e1 = charges[id1]
+            e2 = charges[id2]
+            scaled_x, scaled_y, scaled_z = x / r, y / r, z / r
+            erfc = math.erfc(ewald_coefficient*r)
+            force_val = - e1 * e2 * (
+                2*ewald_coefficient*math.exp(-(ewald_coefficient*r)**2) /
+                math.sqrt(math.pi) + erfc
+            ) / k / r**2
+            force_x = scaled_x * force_val / 2
+            force_y = scaled_y * force_val / 2
+            force_z = scaled_z * force_val / 2
+            cuda.atomic.add(forces, (id1, 0), force_x)
+            cuda.atomic.add(forces, (id1, 1), force_y)
+            cuda.atomic.add(forces, (id1, 2), force_z)
+            cuda.atomic.add(forces, (id2, 0), -force_x)
+            cuda.atomic.add(forces, (id2, 1), -force_y)
+            cuda.atomic.add(forces, (id2, 2), -force_z)
+            energy = e1 * e2 * erfc / k / r / 2
+            cuda.atomic.add(potential_energy, 0, energy)
+
+    @staticmethod
+    def _update_bspline_kernel(positions, grid_size, pbc_inv):
+        num_particles = positions.shape[0]
+        positions = positions - positions.min(0)
+        # spline_coefficient: [num_particles, SPATIAL_DIM, PME_ORDER] The spline coefficient of particles
+        spline_coefficient = np.zeros((num_particles, SPATIAL_DIM, PME_ORDER))
+        # spline_derivative_coefficient: [num_particles, SPATIAL_DIM, PME_ORDER] The derivative spline coefficient of particles
+        spline_derivative_coefficient = np.zeros((num_particles, SPATIAL_DIM, PME_ORDER))
+        scaled_positions = np.dot(positions, pbc_inv)
+        # grid_indice: [num_particles, SPATIAL_DIM] The index of grid where particle assigned to
+        grid_indice = scaled_positions * grid_size
+        # grid_friction: [num_particles, SPATIAL_DIM] The fraction part of particles position relative to gird
+        grid_fraction = grid_indice - np.floor(grid_indice)
+        grid_indice -= grid_fraction
+
+        # 3 order B-spline
+        spline_coefficient[:, :, 2] = 0.5 * grid_fraction**2
+        spline_coefficient[:, :, 0] = 0.5 * (1 - grid_fraction)**2
+        spline_coefficient[:, :, 1] = 1 - spline_coefficient[:, :, 2] - spline_coefficient[:, :, 0]
+
+        # PME_ORDER order derivative coefficient
+        spline_derivative_coefficient[:, :, 0] = - spline_coefficient[:, :, 0]
+        spline_derivative_coefficient[:, :, 1] = spline_coefficient[:, :, 0] - spline_coefficient[:, :, 1]
+        spline_derivative_coefficient[:, :, 2] = spline_coefficient[:, :, 1] - spline_coefficient[:, :, 2]
+        spline_derivative_coefficient[:, :, 3] = spline_coefficient[:, :, 2]
+        # PME_ORDER order spline coefficient
+        spline_coefficient[:, :, 3] = grid_fraction * spline_coefficient[:, :, 2] / 3
+        spline_coefficient[:, :, 2] = (
+            (1 + grid_fraction) * spline_coefficient[:, :, 1] +
+            (3 - grid_fraction) * spline_coefficient[:, :, 2]
+        ) / 3
+        spline_coefficient[:, :, 0] = (1 - grid_fraction) * spline_coefficient[:, :, 0] / 3
+        spline_coefficient[:, :, 1] = (
+            1 - spline_coefficient[:, :, 0] -
+            spline_coefficient[:, :, 2] -
+            spline_coefficient[:, :, 3]
+        )
+        # grid_map: [num_particles, SPATIL_DIM, PME_ORDER]: The indice of grid to add charge of each particles
+        grid_map = np.stack([grid_indice+i for i in [-1, 0, 1, 2]]).transpose(1, 2, 0)
+        for i in range(SPATIAL_DIM):
+            cur_axis_map = grid_map[:, i, :]
+            cur_axis_map[cur_axis_map<0] += grid_size[i]
+            cur_axis_map[cur_axis_map>=grid_size[i]] -= grid_size[i]
+            grid_map[:, i, :] = cur_axis_map
+        return (
+            (spline_coefficient).astype(env.NUMPY_FLOAT),
+            (spline_derivative_coefficient).astype(env.NUMPY_FLOAT),
+            np.ascontiguousarray(grid_map.astype(env.NUMPY_INT))
+        )
+
+    @staticmethod
+    def _update_charge_map_kernel(num_particles, spline_coefficient, grid_map, charges, charge_map):
+        '''
+        spline_coefficient: [num_particles, SPATIAL_DIM, PME_ORDER] The spline coefficient of particles
+        grid_map: [num_particles, SPATIL_DIM, PME_ORDER]: The indice of grid to add charge of each particles
+        charges: [num_particles,]: The charges of particles
+        charge_map: [grid_size_x, grid_size_y, grid_size_z]
+        '''
+        particle_id = cuda.grid(1)
+        num_particles = num_particles[0]
+        if particle_id >= num_particles:
+            return None
+        charge = charges[particle_id]
+        for i in range(PME_ORDER):
+            grid_x = grid_map[particle_id, 0, i]
+            spline_coefficient_x = spline_coefficient[particle_id, 0, i]
+            for j in range(PME_ORDER):
+                grid_y = grid_map[particle_id, 1, j]
+                spline_coefficient_y = spline_coefficient[particle_id, 1, j]
+                for k in range(PME_ORDER):
+                    grid_z = grid_map[particle_id, 2, k]
+                    spline_coefficient_z = spline_coefficient[particle_id, 2, k]
+                    grid_charge = (
+                        charge * spline_coefficient_x *
+                        spline_coefficient_y * spline_coefficient_z
+                    )
+                    cuda.atomic.add(charge_map, (grid_x, grid_y, grid_z), grid_charge)
+
+    @staticmethod
+    def _update_reciprocal_energy_kernel(
+        charge_map, num_grids_total, b_grid, c_grid,
+    ):
+        # Convolution
+        # 332.0636 kcal.A/(mol.e^2)
+        fft_charge = fft.fftn(charge_map * 332.0636)
+        fft_charge[0, 0, 0] = 0
+        potential_energy = (np.abs(fft_charge)**2 * b_grid * c_grid).sum() / num_grids_total / 2
+        potential_energy = Quantity(potential_energy, kilocalorie_permol).convert_to(default_energy_unit).value
+        energy_map = fft.ifftn(fft_charge*b_grid*c_grid).real
+        return potential_energy, energy_map
+
+    @staticmethod
+    def _update_reciprocal_force_kernel(
+        num_particles, spline_coefficient, spline_derivative_coefficient,
+        grid_map, energy_map, charges, forces
+    ):
+        '''
+        spline_coefficient: [num_particles, SPATIAL_DIM, PME_ORDER] The spline coefficient of particles
+        spline_derivative_coefficient: [num_particles, SPATIAL_DIM, PME_ORDER] The spline derivative coefficient of particles
+        grid_map: [num_particles, SPATIL_DIM, PME_ORDER]: The indice of grid to add charge of each particles
+        energy_map: [grid_size_x, grid_size_y, grid_size_z]: Electric potential on each grid point
+        forces: [num_particles, SPATIAL_DIM]
+        '''
+        particle_id = cuda.grid(1)
+        num_particles = num_particles[0]
+        if particle_id >= num_particles:
+            return None
+        charge = charges[particle_id]
+        for i in range(PME_ORDER):
+            grid_x = grid_map[particle_id, 0, i]
+            for j in range(PME_ORDER):
+                grid_y = grid_map[particle_id, 1, j]
+                for k in range(PME_ORDER):
+                    grid_z = grid_map[particle_id, 2, k]
+                    force_x = -(
+                        spline_derivative_coefficient[particle_id, 0, i] *
+                        spline_coefficient[particle_id, 1, j] *
+                        spline_coefficient[particle_id, 2, k] *
+                        energy_map[grid_x, grid_y, grid_z] * charge
+                    )
+                    force_y = -(
+                        spline_coefficient[particle_id, 0, i] *
+                        spline_derivative_coefficient[particle_id, 1, j] *
+                        spline_coefficient[particle_id, 2, k] *
+                        energy_map[grid_x, grid_y, grid_z] * charge
+                    )
+                    force_z = -(
+                        spline_coefficient[particle_id, 0, i] *
+                        spline_coefficient[particle_id, 1, j] *
+                        spline_derivative_coefficient[particle_id, 2, k] *
+                        energy_map[grid_x, grid_y, grid_z] * charge
+                    )
+                    cuda.atomic.add(forces, (particle_id, 0), force_x)
+                    cuda.atomic.add(forces, (particle_id, 1), force_y)
+                    cuda.atomic.add(forces, (particle_id, 2), force_z)
+
+    def update(self):
+        self._forces = np.zeros_like(self._parent_ensemble.state.positions)
+        self._potential_energy = np.zeros([1], dtype=env.NUMPY_FLOAT)
+        device_positions = cuda.to_device(self._parent_ensemble.state.positions)
+        device_forces = cuda.to_device(self._forces)
+        device_potential_energy = cuda.to_device(self._potential_energy)
+        # Direct part
+        device_particle_cell_index = cuda.to_device(self._parent_ensemble.state.cell_list.particle_cell_index)
+        device_cell_list = cuda.to_device(self._parent_ensemble.state.cell_list.cell_list)
+        device_num_cell_vec = cuda.to_device(self._parent_ensemble.state.cell_list.num_cell_vec)
+        device_neighbor_cell_template = cuda.to_device(NEIGHBOR_CELL_TEMPLATE.astype(env.NUMPY_INT))
+        thread_per_block = (8, 8)
+        block_per_grid_x = int(np.ceil(
+            self._parent_ensemble.topology.num_particles / thread_per_block[0]
+        ))
+        block_per_grid_y = int(np.ceil(
+            self._parent_ensemble.state.cell_list.num_particles_per_cell * NUM_NEIGHBOR_CELLS / thread_per_block[1]
+        ))
+        block_per_grid = (block_per_grid_x, block_per_grid_y)
+        self._update_direct_part[block_per_grid, thread_per_block](
+            device_positions, self._device_charges,
+            self._device_k, self._device_ewald_coefficient,
+            self._device_cutoff_radius, self._device_pbc_matrix,
+            self._device_bonded_particles,
+            device_particle_cell_index, device_cell_list,
+            device_num_cell_vec, device_neighbor_cell_template,
+            device_forces, device_potential_energy
+        )
+        forces_direct = device_forces.copy_to_host()
+        potential_energy_direct = device_potential_energy.copy_to_host()[0]
+        # Bspline
+        spline_coefficient, spline_derivative_coefficient, grid_map = self._update_bspline(
+            self._parent_ensemble.state.positions,
+            self._grid_size, self._parent_ensemble.state.pbc_inv
+        )
+        device_spline_coefficient = cuda.to_device(spline_coefficient)
+        device_grid_map = cuda.to_device(grid_map)
+        # Map charge
+        thread_per_block = 64
+        block_per_grid = int(np.ceil(
+            self._parent_ensemble.topology.num_particles / thread_per_block
+        ))
+        device_num_particles = cuda.to_device(np.array(
+            [self._parent_ensemble.topology.num_particles], dtype=env.NUMPY_INT
+        ))
+        device_charges = cuda.to_device(self._parent_ensemble.topology.charges[:, 0])
+        device_charge_map = cuda.to_device(np.zeros(self._grid_size, dtype=env.NUMPY_FLOAT))
+        self._update_charge_map[thread_per_block, block_per_grid](
+            device_num_particles, device_spline_coefficient, device_grid_map,
+            device_charges, device_charge_map
+        )
+        # Reciprocal convolution
+        potential_energy_resciprocal, energy_map = self._update_reciprocal_energy(
+            device_charge_map.copy_to_host(), self._num_grids_total, self._b_grid, self._c_grid
+        )
+        # Reciprocal force
+        device_spline_derivative_coefficient = cuda.to_device(spline_derivative_coefficient)
+        device_energy_map = cuda.to_device(energy_map.astype(env.NUMPY_FLOAT))
+        device_forces = cuda.to_device(np.zeros_like(forces_direct, dtype=env.NUMPY_FLOAT))
+        self._update_reciprocal_force[thread_per_block, block_per_grid](
+            device_num_particles,
+            device_spline_coefficient, device_spline_derivative_coefficient,
+            device_grid_map, device_energy_map, device_charges, device_forces
+        )
+        forces_reciprocal = device_forces.copy_to_host()
+        forces_reciprocal = forces_reciprocal * self._grid_size / np.diagonal(self._parent_ensemble.state.pbc_matrix)
+        forces_reciprocal -= forces_reciprocal.mean(0)
+        forces_reciprocal = Quantity(
+            forces_reciprocal, kilocalorie_permol_over_nanometer
+        ).convert_to(default_force_unit).value
+
+        # Summary
+        self._potential_energy = potential_energy_direct + potential_energy_resciprocal
+        self._forces = forces_direct + forces_reciprocal
+
+    @property
+    def grid_size(self):
+        return self._grid_size
+
+    @property
+    def ewald_coefficient(self):
+        return self._ewald_coefficient
+
+import mdpy as md
+import scipy as sp
+import cupy as cp
+import scipy.fft as fft
+import cupy.fft as cfft
+import matplotlib.pyplot as plt
+if __name__ == '__main__':
+    constraint = ElectrostaticPMEConstraint(Quantity(9, angstrom), direct_sum_energy_tolerance=1e-6)
+    data = sp.io.loadmat('/home/zhenyuwei/Downloads/PME/Tests/cubeions.mat')
+    coordinate, charge = data['crdq'][:, :3], data['crdq'][:, 3]
+    # print(constraint._ewald_coefficient)
+    topology = md.core.Topology()
+    topology.add_particles(
+        [md.core.Particle(charge=i) for i in charge]
+    )
+    ensemble = md.core.Ensemble(topology, np.diag([64]*3))
+    ensemble.add_constraints(constraint)
+    ensemble.state.set_positions(coordinate)
+
+    # s = time.time()
+    # spline_coefficient, spline_derivative_coefficient, grid_map = constraint._bspline_kernel(ensemble.state.positions, constraint._grid_size, ensemble.state.pbc_inv)
+    # e = time.time()
+    # print('Run xxx for %s s' %(e-s))
+
+    # s = time.time()
+    # thread_per_block = 256
+    # block_per_grid = int(np.ceil(
+    #     ensemble.topology.num_particles / thread_per_block
+    # ))
+    # device_num_particles = cuda.to_device(np.array([ensemble.topology.num_particles], dtype=env.NUMPY_INT))
+    # device_spline_coefficient = cuda.to_device(spline_coefficient)
+    # device_grid_map = cuda.to_device(grid_map)
+    # device_charges = cuda.to_device(ensemble.topology.charges[:, 0].astype(env.NUMPY_FLOAT))
+    # device_charge_map = cuda.to_device(np.zeros(constraint._grid_size, dtype=env.NUMPY_FLOAT))
+    # constraint._map_charge[thread_per_block, block_per_grid](
+    #     device_num_particles, device_spline_coefficient, device_grid_map,
+    #     device_charges, device_charge_map
+    # )
+    # e = time.time()
+    # print('Run xxx for %s s' %(e-s))
+
+    # charge_map = device_charge_map.copy_to_host()
+
+    # s = time.time()
+    # energy_map = constraint._update_reciprocal_part_kernel(
+    #     charge_map, constraint._b_grid, constraint._c_grid, constraint._num_grids_total
+    # )
+    # e = time.time()
+    # print('Run xxx for %s s' %(e-s))
+    # fig = plt.figure()
+    # x = np.linspace(-32, 32, constraint._grid_size[0])
+    # y = np.linspace(-32, 32, constraint._grid_size[1])
+    # x, y = np.meshgrid(x, y)
+    # ax1 = fig.add_subplot(211)
+    # c = ax1.contourf(x, y, charge_map[:, :, 32], 100, cmap='RdBu')
+    # plt.colorbar(c)
+    # ax2 = fig.add_subplot(212)
+    # c = ax2.contourf(x, y, energy_map[:, :, 32], 100, cmap='RdBu')
+    # plt.colorbar(c)
+    # fig.tight_layout()
+    # plt.show()
+    # a = cp.array(charge_map)
+    # s = time.time()
+    # fft_charge = fft.fftn(charge_map)
+    # e = time.time()
+    # print('Run xxx for %s s' %(e-s))
+    # print(fft_charge[0, 0, 0])
+
+    s = time.time()
+    constraint.update()
+    e = time.time()
+    print('Run xxx for %s s' %(e-s))
+
+    # print(Quantity(constraint.forces, default_force_unit).convert_to(kilocalorie_permol_over_angstrom).value)
+    # print(Quantity(constraint.potential_energy, default_energy_unit).convert_to(kilocalorie_permol).value)

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -125,13 +125,12 @@ class ElectrostaticPMEConstraint(Constraint):
 
     def _get_grid_size(self):
         '''
-        Set the grid size with spacing around 0.75 angstrom and power to 2 for better fft performance
+        Set the grid size with spacing around 0.5 angstrom and power to 2 for better fft performance
         '''
         pbc_diag = np.diag(Quantity(
             self._parent_ensemble.state.pbc_matrix, default_length_unit
         ).convert_to(angstrom).value)
-        grid_size = np.array([96, 96, 96])
-        # grid_size = np.ceil(pbc_diag/1/2) * 2
+        grid_size = np.ceil(pbc_diag/32) * 32
         return grid_size.astype(env.NUMPY_INT)
 
     def _get_b_grid(self):
@@ -221,8 +220,8 @@ class ElectrostaticPMEConstraint(Constraint):
         self._parent_ensemble = ensemble
         self._force_id = ensemble.constraints.index(self)
         self._charges = self._parent_ensemble.topology.charges[:, 0]
-        # if self._charges.sum() != 0:
-            # raise EnsemblePoorDefinedError('mdpy.constraint.ElectrostaticPMEConstraint is bound to a non-neutralized ensemble')
+        if self._charges.sum() != 0:
+            raise EnsemblePoorDefinedError('mdpy.constraint.ElectrostaticPMEConstraint is bound to a non-neutralized ensemble')
         # Grid size
         self._grid_size = self._get_grid_size()
         self._num_grids_total = np.prod(self._grid_size)

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -556,27 +556,3 @@ class ElectrostaticPMEConstraint(Constraint):
     @property
     def ewald_coefficient(self):
         return self._ewald_coefficient
-
-import mdpy as md
-import scipy as sp
-import cupy as cp
-import scipy.fft as fft
-import cupy.fft as cfft
-import matplotlib.pyplot as plt
-if __name__ == '__main__':
-    constraint = ElectrostaticPMEConstraint(Quantity(9, angstrom), direct_sum_energy_tolerance=1e-6)
-    data = sp.io.loadmat('/home/zhenyuwei/Downloads/PME/Tests/cubeions.mat')
-    coordinate, charge = data['crdq'][:, :3], data['crdq'][:, 3]
-    # print(constraint._ewald_coefficient)
-    topology = md.core.Topology()
-    topology.add_particles(
-        [md.core.Particle(charge=i) for i in charge]
-    )
-    ensemble = md.core.Ensemble(topology, np.diag([64]*3))
-    ensemble.add_constraints(constraint)
-    ensemble.state.set_positions(coordinate)
-
-    s = time.time()
-    constraint.update()
-    e = time.time()
-    print('Run xxx for %s s' %(e-s))

--- a/mdpy/core/__init__.py
+++ b/mdpy/core/__init__.py
@@ -3,6 +3,18 @@ __maintainer__ = "Zhenyu Wei"
 __copyright__ = "(C)Copyright 2021-present, mdpy organization"
 __license__ = "BSD"
 
+import numpy as np
+from mdpy import SPATIAL_DIM, env
+
+NUM_NEIGHBOR_CELLS = SPATIAL_DIM**SPATIAL_DIM
+NEIGHBOR_CELL_TEMPLATE = np.zeros([NUM_NEIGHBOR_CELLS, SPATIAL_DIM], dtype=env.NUMPY_INT)
+index = 0
+for i in range(-1, 2):
+    for j in range(-1, 2):
+        for k in range(-1, 2):
+            NEIGHBOR_CELL_TEMPLATE[index, :] = [i, j, k]
+            index += 1
+
 from mdpy.core.particle import Particle
 from mdpy.core.topology import Topology
 from mdpy.core.cell_list import CellList
@@ -12,6 +24,6 @@ from mdpy.core.ensemble import Ensemble
 
 __all__ = [
     'Particle', 'Topology',
-    'CellList', 'State',
-    'Trajectory', 'Ensemble'
+    'CellList', 'Grid',
+    'State', 'Trajectory', 'Ensemble'
 ]

--- a/mdpy/error.py
+++ b/mdpy/error.py
@@ -168,16 +168,14 @@ class ParserPoorDefinedError(Exception):
     '''
     pass
 
-class DumperPoorDefinedError(Exception):
+class EnsemblePoorDefinedError(Exception):
     '''This error occurs when:
-    - Dump frequency of dumper object is 0
-    - Simulation integrates without adding dumper
-    - LogDumper requires rest_time without providing total_step
+    - A PME constraint is bound to a non-neutralized ensemble
+    - A unsupported long range solver is specified in forcefield object
 
     Used in:
-    - mdpy.dumper.dumper
-    - mdpy.dumper.log_dumper
-    - mdpy.simulation
+    - mdpy.constraint.electrostatic_pme_constraint
+    - mdpy.forcefield.charmm_forcefield
     '''
     pass
 

--- a/mdpy/forcefield/charmm_forcefield.py
+++ b/mdpy/forcefield/charmm_forcefield.py
@@ -98,7 +98,7 @@ class CharmmForcefield(Forcefield):
         ensemble = Ensemble(self._topology, self._pbc_matrix)
         constraints = []
         if self._topology.num_particles != 0:
-            constraints.append(ElectrostaticConstraint())
+            constraints.append(ElectrostaticCutoffConstraint())
             constraints.append(CharmmNonbondedConstraint(self._parameters['nonbonded'], self._cutoff_radius))
         if self._topology.num_bonds != 0:
             constraints.append(CharmmBondConstraint(self._parameters['bond']))

--- a/mdpy/forcefield/charmm_forcefield.py
+++ b/mdpy/forcefield/charmm_forcefield.py
@@ -104,7 +104,7 @@ class CharmmForcefield(Forcefield):
                 constraints.append(ElectrostaticPMEConstraint(
                     self._cutoff_radius, self._ewald_direct_sum_error
                 ))
-            constraints.append(CharmmNonbondedConstraint(self._parameters['nonbonded'], self._cutoff_radius))
+            constraints.append(CharmmVDWConstraint(self._parameters['nonbonded'], self._cutoff_radius))
         if self._topology.num_bonds != 0:
             constraints.append(CharmmBondConstraint(self._parameters['bond']))
         if self._topology.num_angles != 0:

--- a/mdpy/test/run_test.py
+++ b/mdpy/test/run_test.py
@@ -14,8 +14,6 @@ out_dir = os.path.join(cur_dir, 'out')
 if not os.path.exists(out_dir):
     os.mkdir(out_dir)
 
-os.environ['NUMBA_DISABLE_JIT'] = '1'
-
 parser = argparse.ArgumentParser(description='Input of test')
 parser.add_argument('-n', type=int, default = 1)
 args = parser.parse_args()

--- a/mdpy/test/test_charmm_forcefield.py
+++ b/mdpy/test/test_charmm_forcefield.py
@@ -47,7 +47,7 @@ class TestCharmmForcefield:
         f2 = os.path.join(data_dir, 'par_all36_prot.prm')
         f3 = os.path.join(data_dir, 'top_all36_prot.rtf')
         topology = PSFParser(self.psf_file_path).topology
-        forcefield = CharmmForcefield(topology, np.diag([30, 30, 30]))
+        forcefield = CharmmForcefield(topology, np.diag([30, 30, 30]), long_range_solver='CUTOFF')
         forcefield.set_param_files(f1, f2, f3)
         ensemble = forcefield.create_ensemble()
         assert ensemble.num_constraints == 6

--- a/mdpy/test/test_conjugate_gradient_minimizer.py
+++ b/mdpy/test/test_conjugate_gradient_minimizer.py
@@ -35,7 +35,7 @@ class TestConjugrateGradientMinimizer:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100), long_range_solver='CUTOFF')
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
         ensemble.state.cell_list.set_cutoff_radius(12)

--- a/mdpy/test/test_electrostatic_cutoff_constraint.py
+++ b/mdpy/test/test_electrostatic_cutoff_constraint.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 '''
-file : test_electrostatic_constraint.py
+file : test_electrostatic_cutoff_constraint.py
 created time : 2021/10/21
 author : Zhenyu Wei
 copyright : (C)Copyright 2021-present, mdpy organization
@@ -10,7 +10,7 @@ copyright : (C)Copyright 2021-present, mdpy organization
 import pytest, os
 import numpy as np
 from mdpy import env
-from mdpy.constraint import ElectrostaticConstraint
+from mdpy.constraint import ElectrostaticCutoffConstraint
 from mdpy.core import Particle, Topology, Ensemble
 from mdpy.utils import get_unit_vec
 from mdpy.error import *
@@ -19,7 +19,7 @@ from mdpy.unit import *
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
 
-class TestElectrostaticConstraint:
+class TestElectrostaticCutoffConstraint:
     def setup(self):
         p1 = Particle(
             particle_id=0, particle_type='C',
@@ -50,7 +50,7 @@ class TestElectrostaticConstraint:
         self.ensemble = Ensemble(t, np.eye(3)*30)
         self.ensemble.state.cell_list.set_cutoff_radius(12)
         self.ensemble.state.set_positions(self.p)
-        self.constraint = ElectrostaticConstraint()
+        self.constraint = ElectrostaticCutoffConstraint()
 
     def teardown(self):
         self.ensemble, self.parameters, self.constraint = None, None, None

--- a/mdpy/test/test_electrostatic_pme_constraint.py
+++ b/mdpy/test/test_electrostatic_pme_constraint.py
@@ -69,3 +69,36 @@ class TestElectrostaticPMEConstraint:
         # Non-neutralized system
         with pytest.raises(EnsemblePoorDefinedError):
             self.ensemble.add_constraints(self.constraint)
+
+    def test_get_grid_size(self):
+        p1 = Particle(
+            particle_id=0, particle_type='C',
+            particle_name='CA', molecule_type='ASN',
+            mass=12, charge=1
+        )
+        p2 = Particle(
+            particle_id=1, particle_type='N',
+            particle_name='NY', molecule_type='ASN',
+            mass=14, charge=-1
+        )
+        p3 = Particle(
+            particle_id=2, particle_type='CA',
+            particle_name='CPT', molecule_type='ASN',
+            mass=1, charge=0
+        )
+        p4 = Particle(
+            particle_id=3, particle_type='C',
+            particle_name='CA', molecule_type='ASN',
+            mass=12, charge=0
+        )
+        t = Topology()
+        t.add_particles([p1, p2, p3, p4])
+        p = np.array([
+            [0, 0, 0], [0, 10, 0], [0, 21, 0], [0, 11, 0]
+        ])
+        ensemble = Ensemble(t, np.eye(3)*30)
+        ensemble.add_constraints(self.constraint)
+        assert self.constraint._get_grid_size()[0] == 32
+
+        ensemble.state.set_pbc_matrix(np.eye(3)*65)
+        assert self.constraint._get_grid_size()[1] == 96

--- a/mdpy/test/test_electrostatic_pme_constraint.py
+++ b/mdpy/test/test_electrostatic_pme_constraint.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+'''
+file : test_electrostatic_pme_constraint.py
+created time : 2022/04/10
+author : Zhenyu Wei
+version : 1.0
+contact : zhenyuwei99@gmail.com
+copyright : (C)Copyright 2021-2021, Zhenyu Wei and Southeast University
+'''
+
+import pytest, os
+import numpy as np
+from mdpy import env
+from mdpy.constraint import ElectrostaticPMEConstraint
+from mdpy.core import Particle, Topology, Ensemble
+from mdpy.utils import get_unit_vec
+from mdpy.error import *
+from mdpy.unit import *
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+data_dir = os.path.join(cur_dir, 'data')
+
+class TestElectrostaticPMEConstraint:
+    def setup(self):
+        p1 = Particle(
+            particle_id=0, particle_type='C',
+            particle_name='CA', molecule_type='ASN',
+            mass=12, charge=1
+        )
+        p2 = Particle(
+            particle_id=1, particle_type='N',
+            particle_name='NY', molecule_type='ASN',
+            mass=14, charge=2
+        )
+        p3 = Particle(
+            particle_id=2, particle_type='CA',
+            particle_name='CPT', molecule_type='ASN',
+            mass=1, charge=0
+        )
+        p4 = Particle(
+            particle_id=3, particle_type='C',
+            particle_name='CA', molecule_type='ASN',
+            mass=12, charge=0
+        )
+        self.pbc = np.diag(np.ones(3) * 100)
+        t = Topology()
+        t.add_particles([p1, p2, p3, p4])
+        self.p = np.array([
+            [0, 0, 0], [0, 10, 0], [0, 21, 0], [0, 11, 0]
+        ])
+        self.ensemble = Ensemble(t, np.eye(3)*30)
+        self.ensemble.state.cell_list.set_cutoff_radius(12)
+        self.ensemble.state.set_positions(self.p)
+        self.constraint = ElectrostaticPMEConstraint()
+
+    def teardown(self):
+        self.ensemble, self.parameters, self.constraint = None, None, None
+
+    def test_attributes(self):
+        pass
+
+    def test_exceptions(self):
+        with pytest.raises(NonBoundedError):
+            self.constraint._check_bound_state()
+
+    def test_bind_ensemble(self):
+        self.ensemble.state.set_pbc_matrix(self.pbc)
+        # Non-neutralized system
+        with pytest.raises(EnsemblePoorDefinedError):
+            self.ensemble.add_constraints(self.constraint)

--- a/mdpy/test/test_ensemble.py
+++ b/mdpy/test/test_ensemble.py
@@ -77,7 +77,7 @@ class TestEnsemble:
         parameters = charmm_file.parameters
         topology = PSFParser(psf_file_path).topology
         ensemble = Ensemble(topology, np.diag(np.ones(3)*30))
-        constraint = CharmmNonbondedConstraint(parameters['nonbonded'])
+        constraint = CharmmVDWConstraint(parameters['nonbonded'])
         ensemble.add_constraints(constraint)
         assert ensemble.num_constraints == 1
 

--- a/mdpy/test/test_langevin_integrator.py
+++ b/mdpy/test/test_langevin_integrator.py
@@ -35,7 +35,7 @@ class TestVerletIntegrator:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100), long_range_solver='CUTOFF')
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
         ensemble.state.cell_list.set_cutoff_radius(12)

--- a/mdpy/test/test_log_writer.py
+++ b/mdpy/test/test_log_writer.py
@@ -40,7 +40,7 @@ class TestLogWriter:
 
         topology = psf.topology
 
-        forcefield = CharmmForcefield(topology, np.eye(3) * 100)
+        forcefield = CharmmForcefield(topology, np.eye(3) * 100, long_range_solver='CUTOFF')
         forcefield.set_param_files(
             os.path.join(data_dir, 'par_all36_prot.prm'),
             os.path.join(data_dir, 'toppar_water_ions_namd.str')

--- a/mdpy/test/test_log_writer.py
+++ b/mdpy/test/test_log_writer.py
@@ -19,7 +19,7 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
 out_dir = os.path.join(cur_dir, 'out')
 
-class TestLogDumper:
+class TestLogWriter:
     def setup(self):
         self.log_file = os.path.join(out_dir, 'test_log_dumper.log')
 
@@ -30,9 +30,6 @@ class TestLogDumper:
         pass
 
     def test_exceptions(self):
-        with pytest.raises(DumperPoorDefinedError):
-            LogWriter(self.log_file, 100, rest_time=True)
-
         with pytest.raises(FileFormatError):
             LogWriter('test.lo', 10)
 

--- a/mdpy/test/test_steepest_descent_minimizer.py
+++ b/mdpy/test/test_steepest_descent_minimizer.py
@@ -35,7 +35,7 @@ class TestSteepestDescentMinimizer:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100), long_range_solver='CUTOFF')
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
         ensemble.state.cell_list.set_cutoff_radius(12)

--- a/mdpy/test/test_verlet_integrator.py
+++ b/mdpy/test/test_verlet_integrator.py
@@ -34,7 +34,7 @@ class TestVerletIntegrator:
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         topology = PSFParser(os.path.join(data_dir, '6PO6.psf')).topology
 
-        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100))
+        forcefield = CharmmForcefield(topology, np.diag(np.ones(3)*100), long_range_solver='CUTOFF')
         forcefield.set_param_files(os.path.join(data_dir, 'par_all36_prot.prm'))
         ensemble = forcefield.create_ensemble()
         ensemble.state.cell_list.set_cutoff_radius(12)

--- a/mdpy/utils/pbc.py
+++ b/mdpy/utils/pbc.py
@@ -30,7 +30,7 @@ def wrap_positions(positions: np.ndarray, pbc_matrix: np.ndarray, pbc_inv: np.ar
     if np.max(np.abs(move_vec)) >= 2:
         particle_id = np.unique([i[0] for i in np.argwhere(np.abs(move_vec) >= 2)])
         raise ParticleLossError(
-            'Atom(s) with matrix id: %s moved beyond 2 PBC image.' %(particle_id)
+            'Particle(s) with matrix id: %s moved beyond 2 PBC image.' %(particle_id)
         )
     move_vec = np.dot(move_vec, pbc_matrix)
     return positions + move_vec


### PR DESCRIPTION
# Overview
- Add support for PME algorithm, adding `mdpy.constraint.ElectrostaticPMEConstraint`
- Rename `mdpy.constraint.ElectrostaticConstraint` to `mdpy.constraint.ElectrostaticCutoffConstraint`
- Rename `mdpy.constraint.CharmmNonbondedConstraint` to `mdpy.constraint.CharmmVDWConstraint`
- Update `mdpy.forcefiled.CharmmForcefield`
- Remove CPU kernel of `mdpy.constraint.CharmmVDWConstraint` and `mdpy.constraint.ElectrostaticCutoffConstraint`

closes #17 