### PR TITLE
Reduce device host copy

### DIFF
--- a/mdpy/analyser/coordination_number_analyser.py
+++ b/mdpy/analyser/coordination_number_analyser.py
@@ -44,7 +44,7 @@ class CoordinationNumberAnalyser:
                 vec = unwrap_vec(
                     trajectory.positions[frame, id1, :] -
                     trajectory.positions[frame, selected_matrix_ids_2, :],
-                    trajectory.pbc_matrix, trajectory.pbc_inv
+                    trajectory.pbc_diag
                 )
                 dist = np.sqrt((vec**2).sum(1))
                 hist, bin_edge = np.histogram(dist, self._num_bins, [0, self._cutoff_radius])

--- a/mdpy/analyser/rdf_analyser.py
+++ b/mdpy/analyser/rdf_analyser.py
@@ -44,7 +44,7 @@ class RDFAnalyser:
                 vec = unwrap_vec(
                     trajectory.positions[frame, id1, :] -
                     trajectory.positions[frame, selected_matrix_ids_2, :],
-                    trajectory.pbc_matrix, trajectory.pbc_inv
+                    trajectory.pbc_diag
                 )
                 dist = np.sqrt((vec**2).sum(1))
                 cur_hist_id1, bin_edge = np.histogram(dist, self._num_bins, [0, self._cutoff_radius])

--- a/mdpy/analyser/residence_time_analyser.py
+++ b/mdpy/analyser/residence_time_analyser.py
@@ -50,7 +50,7 @@ class ResidenceTimeAnalyser:
             vec = unwrap_vec(
                 trajectory.positions[0, id1, :] -
                 trajectory.positions[0, selected_matrix_ids_2, :],
-                trajectory.pbc_matrix, trajectory.pbc_inv
+                trajectory.pbc_diag
             )
             dist = np.sqrt((vec**2).sum(1))
             neighbor_index = np.where(dist <= self._cutoff_radius)[0]
@@ -69,7 +69,7 @@ class ResidenceTimeAnalyser:
                     vec = unwrap_vec(
                         trajectory.positions[frame, id1, :] -
                         trajectory.positions[frame, id2, :],
-                        trajectory.pbc_matrix, trajectory.pbc_inv
+                        trajectory.pbc_diag
                     )
                     dist = np.sqrt((vec**2).sum())
                     if dist < self._bin_edge[affiliation] or dist > self._bin_edge[affiliation+1]:

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -65,6 +65,9 @@ class CharmmAngleConstraint(Constraint):
             self._num_angles += 1
         self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
         self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._block_per_grid = (int(np.ceil(
+            self._parent_ensemble.topology.num_angles / THREAD_PER_BLOCK
+        )))
 
     @staticmethod
     def _cpu_kernel(int_parameters, float_parameters, positions, pbc_matrix, pbc_inv):
@@ -292,10 +295,7 @@ class CharmmAngleConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        block_per_grid = (int(np.ceil(
-            self._parent_ensemble.topology.num_angles / THREAD_PER_BLOCK
-        )))
-        self._update[block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -292,7 +292,7 @@ class CharmmAngleConstraint(Constraint):
 
     def update(self):
         self._check_bound_state()
-        self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -295,7 +295,7 @@ class CharmmAngleConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        self._update[self._block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -63,8 +63,8 @@ class CharmmAngleConstraint(Constraint):
             # Angle parameters
             self._float_parameters.append(self._parameter_dict[angle_type])
             self._num_angles += 1
-        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
-        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._device_int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._device_float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
         self._block_per_grid = (int(np.ceil(
             self._parent_ensemble.topology.num_angles / THREAD_PER_BLOCK
         )))
@@ -296,8 +296,8 @@ class CharmmAngleConstraint(Constraint):
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
-            self._int_parameters,
-            self._float_parameters,
+            self._device_int_parameters,
+            self._device_float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -63,10 +63,8 @@ class CharmmAngleConstraint(Constraint):
             # Angle parameters
             self._float_parameters.append(self._parameter_dict[angle_type])
             self._num_angles += 1
-        self._int_parameters = np.vstack(self._int_parameters).astype(NUMPY_INT)
-        self._float_parameters = np.vstack(self._float_parameters).astype(NUMPY_FLOAT)
-        self._device_int_parameters = cuda.to_device(self._int_parameters)
-        self._device_float_parameters =cuda.to_device(self._float_parameters)
+        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
 
     @staticmethod
     def _cpu_kernel(int_parameters, float_parameters, positions, pbc_matrix, pbc_inv):
@@ -298,8 +296,8 @@ class CharmmAngleConstraint(Constraint):
             self._parent_ensemble.topology.num_angles / THREAD_PER_BLOCK
         )))
         self._update[block_per_grid, THREAD_PER_BLOCK](
-            self._device_int_parameters,
-            self._device_float_parameters,
+            self._int_parameters,
+            self._float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_angle_constraint.py
+++ b/mdpy/constraint/charmm_angle_constraint.py
@@ -298,7 +298,7 @@ class CharmmAngleConstraint(Constraint):
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_int_parameters,
             self._device_float_parameters,
-            self._parent_ensemble.state.device_positions,
+            self._parent_ensemble.state.positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy
         )

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -68,29 +68,6 @@ class CharmmBondConstraint(Constraint):
         )))
 
     @staticmethod
-    def kernel(int_parameters, float_parameters, positions, pbc_matrix, pbc_inv):
-        forces = np.zeros_like(positions)
-        potential_energy = forces[0, 0]
-        num_parameters = int_parameters.shape[0]
-        for bond in range(num_parameters):
-            id1, id2, = int_parameters[bond, :]
-            k, r0 = float_parameters[bond, :]
-            force_vec = unwrap_vec(
-                positions[id2, :] - positions[id1, :],
-                pbc_matrix, pbc_inv
-            )
-            r = np.linalg.norm(force_vec)
-            force_vec /= r
-            # Forces
-            force_val = 2 * k * (r - r0)
-            force = force_val * force_vec
-            forces[id1, :] += force
-            forces[id2, :] -= force
-            # Potential energy
-            potential_energy += k * (r - r0)**2
-        return forces, potential_energy
-
-    @staticmethod
     def _update_kernel(
         int_parameters, float_parameters,
         positions, pbc_matrix,

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -63,6 +63,9 @@ class CharmmBondConstraint(Constraint):
             self._num_bonds += 1
         self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
         self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._block_per_grid = (int(np.ceil(
+            self._parent_ensemble.topology.num_bonds / THREAD_PER_BLOCK
+        )))
 
     @staticmethod
     def kernel(int_parameters, float_parameters, positions, pbc_matrix, pbc_inv):
@@ -157,10 +160,7 @@ class CharmmBondConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        block_per_grid = (int(np.ceil(
-            self._parent_ensemble.topology.num_bonds / THREAD_PER_BLOCK
-        )))
-        self._update[block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -160,7 +160,7 @@ class CharmmBondConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        self._update[self._block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -61,10 +61,8 @@ class CharmmBondConstraint(Constraint):
             # Bond parameters
             self._float_parameters.append(self._parameter_dict[bond_type])
             self._num_bonds += 1
-        self._int_parameters = np.vstack(self._int_parameters).astype(NUMPY_INT)
-        self._float_parameters = np.vstack(self._float_parameters).astype(NUMPY_FLOAT)
-        self._device_int_parameters = cuda.to_device(self._int_parameters)
-        self._device_float_parameters =cuda.to_device(self._float_parameters)
+        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
 
     @staticmethod
     def kernel(int_parameters, float_parameters, positions, pbc_matrix, pbc_inv):
@@ -163,8 +161,8 @@ class CharmmBondConstraint(Constraint):
             self._parent_ensemble.topology.num_bonds / THREAD_PER_BLOCK
         )))
         self._update[block_per_grid, THREAD_PER_BLOCK](
-            self._device_int_parameters,
-            self._device_float_parameters,
+            self._int_parameters,
+            self._float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -163,7 +163,7 @@ class CharmmBondConstraint(Constraint):
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_int_parameters,
             self._device_float_parameters,
-            self._parent_ensemble.state.device_positions,
+            self._parent_ensemble.state.positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy
         )

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -61,8 +61,8 @@ class CharmmBondConstraint(Constraint):
             # Bond parameters
             self._float_parameters.append(self._parameter_dict[bond_type])
             self._num_bonds += 1
-        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
-        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._device_int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._device_float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
         self._block_per_grid = (int(np.ceil(
             self._parent_ensemble.topology.num_bonds / THREAD_PER_BLOCK
         )))
@@ -161,8 +161,8 @@ class CharmmBondConstraint(Constraint):
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
-            self._int_parameters,
-            self._float_parameters,
+            self._device_int_parameters,
+            self._device_float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_bond_constraint.py
+++ b/mdpy/constraint/charmm_bond_constraint.py
@@ -157,7 +157,7 @@ class CharmmBondConstraint(Constraint):
 
     def update(self):
         self._check_bound_state()
-        self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -207,7 +207,7 @@ class CharmmDihedralConstraint(Constraint):
     def update(self):
         self._check_bound_state()
         # V(dihedral) = Kchi(1 + cos(n(chi) - delta))
-        self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -67,10 +67,8 @@ class CharmmDihedralConstraint(Constraint):
                 # dihedral coefficient
                 self._float_parameters.append(float_param)
             self._num_dihedrals += 1
-        self._int_parameters = np.vstack(self._int_parameters).astype(NUMPY_INT)
-        self._float_parameters = np.vstack(self._float_parameters).astype(NUMPY_FLOAT)
-        self._device_int_parameters = cuda.to_device(self._int_parameters)
-        self._device_float_parameters = cuda.to_device(self._float_parameters)
+        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
 
     @staticmethod
     def _update_kernel(
@@ -213,8 +211,8 @@ class CharmmDihedralConstraint(Constraint):
             self._parent_ensemble.topology.num_dihedrals / THREAD_PER_BLOCK
         )))
         self._update[block_per_grid, THREAD_PER_BLOCK](
-            self._device_int_parameters,
-            self._device_float_parameters,
+            self._int_parameters,
+            self._float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -213,7 +213,7 @@ class CharmmDihedralConstraint(Constraint):
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_int_parameters,
             self._device_float_parameters,
-            self._parent_ensemble.state.device_positions,
+            self._parent_ensemble.state.positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy
         )

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -210,7 +210,7 @@ class CharmmDihedralConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        self._update[self._block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -69,6 +69,9 @@ class CharmmDihedralConstraint(Constraint):
             self._num_dihedrals += 1
         self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
         self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._block_per_grid = (int(np.ceil(
+            self._parent_ensemble.topology.num_dihedrals / THREAD_PER_BLOCK
+        )))
 
     @staticmethod
     def _update_kernel(
@@ -207,10 +210,7 @@ class CharmmDihedralConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        block_per_grid = (int(np.ceil(
-            self._parent_ensemble.topology.num_dihedrals / THREAD_PER_BLOCK
-        )))
-        self._update[block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_dihedral_constraint.py
+++ b/mdpy/constraint/charmm_dihedral_constraint.py
@@ -67,8 +67,8 @@ class CharmmDihedralConstraint(Constraint):
                 # dihedral coefficient
                 self._float_parameters.append(float_param)
             self._num_dihedrals += 1
-        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
-        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._device_int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._device_float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
         self._block_per_grid = (int(np.ceil(
             self._parent_ensemble.topology.num_dihedrals / THREAD_PER_BLOCK
         )))
@@ -211,8 +211,8 @@ class CharmmDihedralConstraint(Constraint):
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
-            self._int_parameters,
-            self._float_parameters,
+            self._device_int_parameters,
+            self._device_float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_improper_constraint.py
+++ b/mdpy/constraint/charmm_improper_constraint.py
@@ -203,7 +203,7 @@ class CharmmImproperConstraint(Constraint):
     def update(self):
         self._check_bound_state()
         # V(improper) = Kpsi(psi - psi0)**2
-        self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](

--- a/mdpy/constraint/charmm_improper_constraint.py
+++ b/mdpy/constraint/charmm_improper_constraint.py
@@ -209,7 +209,7 @@ class CharmmImproperConstraint(Constraint):
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_int_parameters,
             self._device_float_parameters,
-            self._parent_ensemble.state.device_positions,
+            self._parent_ensemble.state.positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy
         )

--- a/mdpy/constraint/charmm_improper_constraint.py
+++ b/mdpy/constraint/charmm_improper_constraint.py
@@ -63,10 +63,8 @@ class CharmmImproperConstraint(Constraint):
             ])
             self._float_parameters.append(self._parameter_dict[improper_type])
             self._num_impropers += 1
-        self._int_parameters = np.vstack(self._int_parameters).astype(NUMPY_INT)
-        self._float_parameters = np.vstack(self._float_parameters).astype(NUMPY_FLOAT)
-        self._device_int_parameters = cuda.to_device(self._int_parameters)
-        self._device_float_parameters = cuda.to_device(self._float_parameters)
+        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
 
     @staticmethod
     def _update_kernel(
@@ -209,8 +207,8 @@ class CharmmImproperConstraint(Constraint):
             self._parent_ensemble.topology.num_impropers / THREAD_PER_BLOCK
         )))
         self._update[block_per_grid, THREAD_PER_BLOCK](
-            self._device_int_parameters,
-            self._device_float_parameters,
+            self._int_parameters,
+            self._float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_improper_constraint.py
+++ b/mdpy/constraint/charmm_improper_constraint.py
@@ -206,7 +206,7 @@ class CharmmImproperConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        self._update[self._block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._int_parameters,
             self._float_parameters,
             self._parent_ensemble.state.device_positions,

--- a/mdpy/constraint/charmm_improper_constraint.py
+++ b/mdpy/constraint/charmm_improper_constraint.py
@@ -63,8 +63,8 @@ class CharmmImproperConstraint(Constraint):
             ])
             self._float_parameters.append(self._parameter_dict[improper_type])
             self._num_impropers += 1
-        self._int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
-        self._float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
+        self._device_int_parameters = cp.array(np.vstack(self._int_parameters), CUPY_INT)
+        self._device_float_parameters = cp.array(np.vstack(self._float_parameters), CUPY_FLOAT)
         self._block_per_grid = (int(np.ceil(
             self._parent_ensemble.topology.num_impropers / THREAD_PER_BLOCK
         )))
@@ -207,8 +207,8 @@ class CharmmImproperConstraint(Constraint):
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
-            self._int_parameters,
-            self._float_parameters,
+            self._device_int_parameters,
+            self._device_float_parameters,
             self._parent_ensemble.state.device_positions,
             self._parent_ensemble.state.device_pbc_matrix,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_vdw_constraint.py
+++ b/mdpy/constraint/charmm_vdw_constraint.py
@@ -155,7 +155,7 @@ class CharmmVDWConstraint(Constraint):
 
     def update(self):
         self._check_bound_state()
-        self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](

--- a/mdpy/constraint/charmm_vdw_constraint.py
+++ b/mdpy/constraint/charmm_vdw_constraint.py
@@ -161,7 +161,7 @@ class CharmmVDWConstraint(Constraint):
             self._device_parameters_list,
             self._parent_ensemble.topology.device_bonded_particles,
             self._parent_ensemble.topology.device_scaling_particles,
-            self._parent_ensemble.state.neighbor_list.device_neighbor_list,
-            self._parent_ensemble.state.neighbor_list.device_neighbor_vec_list,
+            self._parent_ensemble.state.neighbor_list.neighbor_list,
+            self._parent_ensemble.state.neighbor_list.neighbor_vec_list,
             self._forces, self._potential_energy
         )

--- a/mdpy/constraint/charmm_vdw_constraint.py
+++ b/mdpy/constraint/charmm_vdw_constraint.py
@@ -57,9 +57,7 @@ class CharmmVDWConstraint(Constraint):
             elif len(param) == 4:
                 epsilon, sigma, epsilon14, sigma14 = param
                 self._parameters_list.append([epsilon, sigma, epsilon14, sigma14])
-        self._parameters_list = cp.array(np.vstack(self._parameters_list), CUPY_FLOAT)
-        self._bonded_particles = cp.array(self._parent_ensemble.topology.bonded_particles, CUPY_INT)
-        self._scaling_particles = cp.array(self._parent_ensemble.topology.scaling_particles, CUPY_INT)
+        self._device_parameters_list = cp.array(np.vstack(self._parameters_list), CUPY_FLOAT)
         self._block_per_grid = int(np.ceil(
             self._parent_ensemble.topology.num_particles / THREAD_PER_BLOCK
         ))
@@ -160,9 +158,9 @@ class CharmmVDWConstraint(Constraint):
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_cutoff_radius,
-            self._parameters_list,
-            self._bonded_particles,
-            self._scaling_particles,
+            self._device_parameters_list,
+            self._parent_ensemble.topology.device_bonded_particles,
+            self._parent_ensemble.topology.device_scaling_particles,
             self._parent_ensemble.state.neighbor_list.device_neighbor_list,
             self._parent_ensemble.state.neighbor_list.device_neighbor_vec_list,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_vdw_constraint.py
+++ b/mdpy/constraint/charmm_vdw_constraint.py
@@ -25,7 +25,7 @@ class CharmmVDWConstraint(Constraint):
         # Attributes
         self._parameter_dict = parameter_dict
         self._cutoff_radius = check_quantity_value(cutoff_radius, default_length_unit)
-        self._device_cutoff_radius = cuda.to_device(np.array([self._cutoff_radius]))
+        self._device_cutoff_radius = cp.array([self._cutoff_radius], CUPY_FLOAT)
         self._parameters_list = []
         # Kernel
         self._update = cuda.jit(nb.void(
@@ -57,10 +57,9 @@ class CharmmVDWConstraint(Constraint):
             elif len(param) == 4:
                 epsilon, sigma, epsilon14, sigma14 = param
                 self._parameters_list.append([epsilon, sigma, epsilon14, sigma14])
-        self._parameters_list = np.vstack(self._parameters_list).astype(NUMPY_FLOAT)
-        self._device_parameters_list = cuda.to_device(self._parameters_list)
-        self._device_bonded_particles = cuda.to_device(self._parent_ensemble.topology.bonded_particles)
-        self._device_scaling_particles = cuda.to_device(self._parent_ensemble.topology.scaling_particles)
+        self._parameters_list = cp.array(np.vstack(self._parameters_list), CUPY_FLOAT)
+        self._bonded_particles = cp.array(self._parent_ensemble.topology.bonded_particles, CUPY_INT)
+        self._scaling_particles = cp.array(self._parent_ensemble.topology.scaling_particles, CUPY_INT)
         self._block_per_grid = int(np.ceil(
             self._parent_ensemble.topology.num_particles / THREAD_PER_BLOCK
         ))
@@ -161,9 +160,9 @@ class CharmmVDWConstraint(Constraint):
         # Device
         self._update[self._block_per_grid, THREAD_PER_BLOCK](
             self._device_cutoff_radius,
-            self._device_parameters_list,
-            self._device_bonded_particles,
-            self._device_scaling_particles,
+            self._parameters_list,
+            self._bonded_particles,
+            self._scaling_particles,
             self._parent_ensemble.state.neighbor_list.device_neighbor_list,
             self._parent_ensemble.state.neighbor_list.device_neighbor_vec_list,
             self._forces, self._potential_energy

--- a/mdpy/constraint/charmm_vdw_constraint.py
+++ b/mdpy/constraint/charmm_vdw_constraint.py
@@ -158,7 +158,7 @@ class CharmmVDWConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Device
-        self._update[self._block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_cutoff_radius,
             self._parameters_list,
             self._bonded_particles,

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -129,7 +129,7 @@ class ElectrostaticCutoffConstraint(Constraint):
         self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Update
-        self._update[self._block_per_grid, THREAD_PER_BLOCK](
+        self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._charges, self._k,
             self._device_cutoff_radius,
             self._bonded_particles,

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -131,7 +131,7 @@ class ElectrostaticCutoffConstraint(Constraint):
             self._parent_ensemble.topology.device_charges, self._device_k,
             self._device_cutoff_radius,
             self._parent_ensemble.topology.device_bonded_particles,
-            self._parent_ensemble.state.neighbor_list.device_neighbor_list,
-            self._parent_ensemble.state.neighbor_list.device_neighbor_vec_list,
+            self._parent_ensemble.state.neighbor_list.neighbor_list,
+            self._parent_ensemble.state.neighbor_list.neighbor_vec_list,
             self._forces, self._potential_energy
         )

--- a/mdpy/constraint/electrostatic_cutoff_constraint.py
+++ b/mdpy/constraint/electrostatic_cutoff_constraint.py
@@ -126,7 +126,7 @@ class ElectrostaticCutoffConstraint(Constraint):
 
     def update(self):
         self._check_bound_state()
-        self._forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Update
         self._update[self._block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -526,7 +526,7 @@ class ElectrostaticPMEConstraint(Constraint):
 
     def update(self):
         self._check_bound_state()
-        self._direct_forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._direct_forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._direct_potential_energy = cp.zeros([1], CUPY_FLOAT)
         # Direct part
         block_per_grid = int(np.ceil(
@@ -572,7 +572,7 @@ class ElectrostaticPMEConstraint(Constraint):
             self._device_k, self._charge_map, self._device_bc_grid
         )
         # Reciprocal force
-        self._reciprocal_forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
+        self._reciprocal_forces = cp.zeros(self._parent_ensemble.state.matrix_shape, CUPY_FLOAT)
         self._reciprocal_potential_energy = cp.zeros([1], CUPY_FLOAT)
         self._update_reciprocal_force[block_per_grid, thread_per_block, self._parent_ensemble.streams[self._constraint_id]](
             self._device_num_particles,

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -532,7 +532,7 @@ class ElectrostaticPMEConstraint(Constraint):
         block_per_grid = int(np.ceil(
             self._parent_ensemble.topology.num_particles / THREAD_PER_BLOCK
         ))
-        self._update_direct_part[block_per_grid, THREAD_PER_BLOCK](
+        self._update_direct_part[block_per_grid, THREAD_PER_BLOCK, self._parent_ensemble.streams[self._constraint_id]](
             self._device_charges,
             self._device_k,
             self._device_ewald_coefficient,
@@ -563,7 +563,7 @@ class ElectrostaticPMEConstraint(Constraint):
         )
         # Map charge
         self._charge_map = cp.zeros(self._grid_size, CUPY_FLOAT)
-        self._update_charge_map[block_per_grid, thread_per_block](
+        self._update_charge_map[block_per_grid, thread_per_block, self._parent_ensemble.streams[self._constraint_id]](
             self._device_num_particles, spline_coefficient, grid_map,
             self._device_charges, self._charge_map
         )
@@ -574,7 +574,7 @@ class ElectrostaticPMEConstraint(Constraint):
         # Reciprocal force
         self._reciprocal_forces = cp.zeros_like(self._parent_ensemble.state.positions, CUPY_FLOAT)
         self._reciprocal_potential_energy = cp.zeros([1], CUPY_FLOAT)
-        self._update_reciprocal_force[block_per_grid, thread_per_block](
+        self._update_reciprocal_force[block_per_grid, thread_per_block, self._parent_ensemble.streams[self._constraint_id]](
             self._device_num_particles,
             spline_coefficient,
             spline_derivative_coefficient,

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -534,8 +534,8 @@ class ElectrostaticPMEConstraint(Constraint):
             self._device_ewald_coefficient,
             self._device_cutoff_radius,
             self._parent_ensemble.topology.device_bonded_particles,
-            self._parent_ensemble.state.neighbor_list.device_neighbor_list,
-            self._parent_ensemble.state.neighbor_list.device_neighbor_vec_list,
+            self._parent_ensemble.state.neighbor_list.neighbor_list,
+            self._parent_ensemble.state.neighbor_list.neighbor_vec_list,
             self._direct_forces, self._direct_potential_energy
         )
         thread_per_block = (64)

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -553,7 +553,7 @@ class ElectrostaticPMEConstraint(Constraint):
             [self._parent_ensemble.topology.num_particles, SPATIAL_DIM, PME_ORDER], CUPY_INT
         )
         self._update_bspline[block_per_grid, thread_per_block](
-            self._parent_ensemble.state.device_positions, self._device_grid_size,
+            self._parent_ensemble.state.positions, self._device_grid_size,
             self._parent_ensemble.state.device_pbc_matrix,
             spline_coefficient, spline_derivative_coefficient, grid_map
         )

--- a/mdpy/constraint/electrostatic_pme_constraint.py
+++ b/mdpy/constraint/electrostatic_pme_constraint.py
@@ -249,7 +249,6 @@ class ElectrostaticPMEConstraint(Constraint):
         )
         self._device_self_potential_energy = cp.array(self._self_potential_energy, CUPY_FLOAT)
         self._device_charges = cp.array(self._charges, CUPY_FLOAT)
-        self._device_cutoff_radius = cp.array([self._cutoff_radius], CUPY_FLOAT)
         self._device_bonded_particles = cp.array(self._parent_ensemble.topology.bonded_particles, CUPY_INT)
         self._device_b_grid = cp.array(self._b_grid, CUPY_FLOAT)
         self._device_c_grid = cp.array(self._c_grid, CUPY_FLOAT)

--- a/mdpy/core/ensemble.py
+++ b/mdpy/core/ensemble.py
@@ -23,7 +23,7 @@ class Ensemble:
         self._topology = topology
         self._state = State(self._topology, pbc_matrix)
         self._matrix_shape = self._state.matrix_shape
-        self._forces = np.zeros(self._matrix_shape)
+        self._forces = cp.zeros(self._matrix_shape)
 
         self._total_energy = 0
         self._potential_energy = 0

--- a/mdpy/core/ensemble.py
+++ b/mdpy/core/ensemble.py
@@ -65,8 +65,7 @@ class Ensemble:
         for constraint in self._constraints:
             self._forces += constraint.forces
             self._potential_energy += constraint.potential_energy
-        self._forces = self._forces.get()
-        self._potential_energy = self._potential_energy.get()
+        self._potential_energy = self._potential_energy
         self._update_kinetic_energy()
         self._total_energy = self._potential_energy + self._kinetic_energy
 
@@ -74,7 +73,7 @@ class Ensemble:
         # Without reshape, the result of the first sum will be a 1d vector
         # , which will be a matrix after multiple with a 2d vector
         self._kinetic_energy = ((
-            (self._state.velocities**2).sum(1).reshape(self._topology.num_particles, 1) * self._topology.masses
+            (self._state.velocities**2).sum(1) * self._topology.device_masses[:, 0]
         ).sum() / 2)
 
     @property

--- a/mdpy/core/neighbor_list.py
+++ b/mdpy/core/neighbor_list.py
@@ -309,8 +309,8 @@ class NeighborList:
                 positions.get(), self._pbc_diag,
                 self._num_cells_vec, self._cell_width
             )
-            self._device_neighbor_list = cp.zeros((positions.shape[0], num_max_neighbors_per_particle), CUPY_INT) - 1
-            self._device_neighbor_vec_list = cp.zeros((positions.shape[0], num_max_neighbors_per_particle, SPATIAL_DIM+1), CUPY_FLOAT)
+            self._neighbor_list = cp.zeros((positions.shape[0], num_max_neighbors_per_particle), CUPY_INT) - 1
+            self._neighbor_vec_list = cp.zeros((positions.shape[0], num_max_neighbors_per_particle, SPATIAL_DIM+1), CUPY_FLOAT)
             device_particle_cell_index = cp.array(self._particle_cell_index, CUPY_INT)
             device_cell_list = cp.array(self._cell_list, CUPY_INT)
             self._update_neighbor_list[block_per_grid, THREAD_PER_BLOCK](
@@ -322,15 +322,15 @@ class NeighborList:
                 self._device_cutoff_radius,
                 self._device_skin_width,
                 self._device_neighbor_ceil_shift,
-                self._device_neighbor_list,
-                self._device_neighbor_vec_list
+                self._neighbor_list,
+                self._neighbor_vec_list
             )
         else:
             self._update_neighbor_vec_list[block_per_grid, THREAD_PER_BLOCK](
                 positions,
                 self._device_pbc_matrix,
-                self._device_neighbor_list,
-                self._device_neighbor_vec_list
+                self._neighbor_list,
+                self._neighbor_vec_list
             )
 
     @property
@@ -342,9 +342,9 @@ class NeighborList:
         return self._pbc_matrix
 
     @property
-    def device_neighbor_list(self):
-        return self._device_neighbor_list
+    def neighbor_list(self):
+        return self._neighbor_list
 
     @property
-    def device_neighbor_vec_list(self):
-        return self._device_neighbor_vec_list
+    def neighbor_vec_list(self):
+        return self._neighbor_vec_list

--- a/mdpy/core/neighbor_list.py
+++ b/mdpy/core/neighbor_list.py
@@ -292,7 +292,6 @@ class NeighborList:
         num_max_neighbors_per_particle = int(np.ceil(
             num_particles / self._pbc_volume * self._cutoff_volume * 1.3
         ))
-        print(num_max_neighbors_per_particle)
         if num_particles < NUM_MIN_NEIGHBORS:
             return num_particles
         elif num_max_neighbors_per_particle < NUM_MIN_NEIGHBORS:

--- a/mdpy/core/topology.py
+++ b/mdpy/core/topology.py
@@ -74,8 +74,8 @@ class Topology:
         for index, particle in enumerate(self._particles):
             self._bonded_particles[index, :particle.num_bonded_particles] = particle.bonded_particles
             self._scaling_particles[index, :particle.num_scaling_particles] = particle.scaling_particles
-        self._device_charges = cp.array(self._charges, CUPY_FLOAT)
         self._device_masses = cp.array(self._masses, CUPY_FLOAT)
+        self._device_charges = cp.array(self._charges, CUPY_FLOAT)
         self._device_bonded_particles = cp.array(self._bonded_particles, CUPY_INT)
         self._device_scaling_particles = cp.array(self._scaling_particles, CUPY_INT)
         self._is_joined = True
@@ -255,7 +255,7 @@ class Topology:
 
     @property
     def device_charges(self):
-        return self._charges
+        return self._device_charges
 
     @property
     def bonded_particles(self):

--- a/mdpy/core/topology.py
+++ b/mdpy/core/topology.py
@@ -244,7 +244,7 @@ class Topology:
     @property
     def masses(self):
         return self._masses
-    
+
     @property
     def device_masses(self):
         return self._device_masses
@@ -252,7 +252,7 @@ class Topology:
     @property
     def charges(self):
         return self._charges
-    
+
     @property
     def device_charges(self):
         return self._charges

--- a/mdpy/core/topology.py
+++ b/mdpy/core/topology.py
@@ -8,9 +8,11 @@ copyright : (C)Copyright 2021-present, mdpy organization
 '''
 
 import numpy as np
+import cupy as cp
 from mdpy import env
 from mdpy.core import MAX_NUM_BONDED_PARTICLES, MAX_NUM_SCALING_PARTICLES
 from mdpy.core import Particle
+from mdpy.environment import CUPY_FLOAT, CUPY_INT
 from mdpy.error import *
 from mdpy.unit import *
 
@@ -72,6 +74,10 @@ class Topology:
         for index, particle in enumerate(self._particles):
             self._bonded_particles[index, :particle.num_bonded_particles] = particle.bonded_particles
             self._scaling_particles[index, :particle.num_scaling_particles] = particle.scaling_particles
+        self._device_charges = cp.array(self._charges, CUPY_FLOAT)
+        self._device_masses = cp.array(self._masses, CUPY_FLOAT)
+        self._device_bonded_particles = cp.array(self._bonded_particles, CUPY_INT)
+        self._device_scaling_particles = cp.array(self._scaling_particles, CUPY_INT)
         self._is_joined = True
 
     def split(self):
@@ -238,9 +244,17 @@ class Topology:
     @property
     def masses(self):
         return self._masses
+    
+    @property
+    def device_masses(self):
+        return self._device_masses
 
     @property
     def charges(self):
+        return self._charges
+    
+    @property
+    def device_charges(self):
         return self._charges
 
     @property
@@ -248,8 +262,16 @@ class Topology:
         return self._bonded_particles
 
     @property
+    def device_bonded_particles(self):
+        return self._device_bonded_particles
+
+    @property
     def scaling_particles(self):
         return self._scaling_particles
+
+    @property
+    def device_scaling_particles(self):
+        return self._device_scaling_particles
 
     @property
     def particles(self) -> list[Particle]:

--- a/mdpy/core/trajectory.py
+++ b/mdpy/core/trajectory.py
@@ -58,7 +58,7 @@ class Trajectory:
         # So the scaled position will be Position * PBC instead of PBC * Position as usual
         self._pbc_matrix = np.ascontiguousarray(pbc_matrix, dtype=env.NUMPY_FLOAT)
         self._pbc_inv = np.ascontiguousarray(np.linalg.inv(self._pbc_matrix), dtype=env.NUMPY_FLOAT)
-        self._pbc_inv = np.ascontiguousarray(np.diagonal(self._pbc_matrix), dtype=env.NUMPY_FLOAT)
+        self._pbc_diag = np.ascontiguousarray(np.diagonal(self._pbc_matrix), dtype=env.NUMPY_FLOAT)
         self._is_pbc_specified = True
 
     def _check_array(self, array: np.ndarray):
@@ -184,7 +184,7 @@ class Trajectory:
     def pbc_diag(self):
         if not self._is_pbc_specified:
             raise PBCPoorDefinedError('PBC has not been specified before calling.')
-        return self._pbc_inv
+        return self._pbc_diag
 
     @property
     def positions(self):

--- a/mdpy/core/trajectory.py
+++ b/mdpy/core/trajectory.py
@@ -36,6 +36,7 @@ class Trajectory:
 
         self._pbc_matrix = np.zeros([SPATIAL_DIM, SPATIAL_DIM], dtype=env.NUMPY_FLOAT)
         self._pbc_inv = np.zeros([SPATIAL_DIM, SPATIAL_DIM], dtype=env.NUMPY_FLOAT)
+        self._pbc_diag = np.zeros([SPATIAL_DIM], dtype=env.NUMPY_FLOAT)
         self._is_pbc_specified = False
         self._time_step = None
 
@@ -57,6 +58,7 @@ class Trajectory:
         # So the scaled position will be Position * PBC instead of PBC * Position as usual
         self._pbc_matrix = np.ascontiguousarray(pbc_matrix, dtype=env.NUMPY_FLOAT)
         self._pbc_inv = np.ascontiguousarray(np.linalg.inv(self._pbc_matrix), dtype=env.NUMPY_FLOAT)
+        self._pbc_inv = np.ascontiguousarray(np.diagonal(self._pbc_matrix), dtype=env.NUMPY_FLOAT)
         self._is_pbc_specified = True
 
     def _check_array(self, array: np.ndarray):
@@ -174,6 +176,12 @@ class Trajectory:
 
     @property
     def pbc_inv(self):
+        if not self._is_pbc_specified:
+            raise PBCPoorDefinedError('PBC has not been specified before calling.')
+        return self._pbc_inv
+
+    @property
+    def pbc_diag(self):
         if not self._is_pbc_specified:
             raise PBCPoorDefinedError('PBC has not been specified before calling.')
         return self._pbc_inv

--- a/mdpy/integrator/verlet_integrator.py
+++ b/mdpy/integrator/verlet_integrator.py
@@ -20,7 +20,7 @@ class VerletIntegrator(Integrator):
     def integrate(self, ensemble: Ensemble, num_steps: int=1):
         # Setting variables
         cur_step = 0
-        masses = ensemble.topology.masses
+        masses = ensemble.topology.device_masses
         # Update force
         ensemble.update()
         accelration = ensemble.forces / masses
@@ -37,6 +37,7 @@ class VerletIntegrator(Integrator):
                 ensemble.update()
                 accelration = ensemble.forces / masses
             # Update positions and velocities
+            import time
             self._cur_positions, self._pre_positions = (
                 2 * self._cur_positions - self._pre_positions +
                 accelration * self._time_step_square
@@ -48,6 +49,5 @@ class VerletIntegrator(Integrator):
             # Update step
             cur_step += 1
         ensemble.state.set_velocities(unwrap_vec(
-            (self._cur_positions - self._pre_positions).astype(env.NUMPY_FLOAT),
-            *ensemble.state.pbc_info
+            self._cur_positions - self._pre_positions, ensemble.state.device_pbc_diag
         ) / 2 / self._time_step)

--- a/mdpy/minimizer/conjugate_gradient_minimizer.py
+++ b/mdpy/minimizer/conjugate_gradient_minimizer.py
@@ -46,10 +46,10 @@ class ConjugateGradientMinimizer(Minimizer):
                 cur_f = ensemble.forces.reshape([-1, 1])
                 pre_f = cur_f.copy()
                 t = cur_f.copy()
-                ensemble.state.set_positions(wrap_positions(
+                ensemble.state.set_positions(
                     ensemble.state.positions + self._theta * t.reshape([-1, 3]),
                     *ensemble.state.pbc_info
-                ))
+                )
                 ensemble.update()
                 omega = - (ensemble.forces.reshape([-1, 1]) - cur_f) / self._theta
                 alpha = np.matmul(cur_f.T, cur_f) / (np.matmul(omega.T, t))

--- a/mdpy/test/test_charmm_vdw_constraint.py
+++ b/mdpy/test/test_charmm_vdw_constraint.py
@@ -83,8 +83,8 @@ class TestCharmmVDWConstraint:
         # NY     0.000000  -0.200000     1.850000
         # CPT    0.000000  -0.099000     1.860000
         self.ensemble.state.set_pbc_matrix(self.pbc)
-        assert self.constraint._parameters_list[0, 0] == Quantity(0.07, kilocalorie_permol).convert_to(default_energy_unit).value
-        assert self.constraint._parameters_list[1, 1] == pytest.approx(env.NUMPY_FLOAT(1.85 * RMIN_TO_SIGMA_FACTOR * 2))
+        assert self.constraint._parameters_list[0][0] == Quantity(0.07, kilocalorie_permol).convert_to(default_energy_unit).value
+        assert self.constraint._parameters_list[1][1] == pytest.approx(env.NUMPY_FLOAT(1.85 * RMIN_TO_SIGMA_FACTOR * 2))
 
         # No exception
         self.constraint._check_bound_state()

--- a/mdpy/test/test_geometry.py
+++ b/mdpy/test/test_geometry.py
@@ -35,22 +35,6 @@ def test_get_bond():
     position2 = [3, 2, 2]
     assert get_bond(position2, position1) == pytest.approx(np.sqrt(14))
 
-def test_get_pbc_bond():
-    pbc_matrix = np.diag(np.ones(3)*10).astype(env.NUMPY_FLOAT)
-    pbc_inv = np.linalg.inv(pbc_matrix).astype(env.NUMPY_FLOAT)
-
-    position1 = np.array([0, 1, 0]).astype(env.NUMPY_FLOAT)
-    position2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    assert get_pbc_bond(position1, position2, pbc_matrix, pbc_inv) == 1
-
-    position1 = np.array([0, 5, 0]).astype(env.NUMPY_FLOAT)
-    position2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    assert get_pbc_bond(position1, position2, pbc_matrix, pbc_inv) == 5
-
-    position1 = np.array([0, 6, 0]).astype(env.NUMPY_FLOAT)
-    position2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    assert get_pbc_bond(position1, position2, pbc_matrix, pbc_inv) == pytest.approx(4)
-
 def test_get_angle():
     p1 = np.array([1, 1])
     p2 = np.array([0, 0])
@@ -60,27 +44,6 @@ def test_get_angle():
 
     angle = get_angle(p1, p2, p3, is_angular=False)
     assert angle == pytest.approx(45)
-
-def test_get_pbc_angle():
-    pbc_matrix = np.diag(np.ones(3)*10).astype(env.NUMPY_FLOAT)
-    pbc_inv = np.linalg.inv(pbc_matrix).astype(env.NUMPY_FLOAT)
-
-    p1 = np.array([1, 1, 0]).astype(env.NUMPY_FLOAT)
-    p2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    p3 = np.array([0, 1, 0]).astype(env.NUMPY_FLOAT)
-    angle = get_pbc_angle(p1, p2, p3, pbc_matrix, pbc_inv)
-    assert angle == pytest.approx(np.pi / 4)
-
-    p1 = np.array([11, 1, 0]).astype(env.NUMPY_FLOAT)
-    p2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    p3 = np.array([0, 1, 0]).astype(env.NUMPY_FLOAT)
-    angle = get_pbc_angle(p1, p2, p3, pbc_matrix, pbc_inv)
-    assert angle == pytest.approx(np.pi / 4)
-    p1 = np.array([1, 1, 0]).astype(env.NUMPY_FLOAT) + 5
-    p2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT) + 5
-    p3 = np.array([0, 1, 0]).astype(env.NUMPY_FLOAT) + 5
-    angle = get_pbc_angle(p1, p2, p3, pbc_matrix, pbc_inv)
-    assert angle == pytest.approx(np.pi / 4)
 
 def test_get_included_angle():
     p1 = np.array([1, 1])
@@ -157,31 +120,3 @@ def test_get_dihedral():
 
     improper = get_dihedral(p1, p2, p3, p4, is_angular=False)
     assert improper == pytest.approx(-90)
-
-def test_get_pbc_dihedral():
-    pbc_matrix = np.diag(np.ones(3)*10).astype(env.NUMPY_FLOAT)
-    pbc_inv = np.linalg.inv(pbc_matrix).astype(env.NUMPY_FLOAT)
-
-    p1 = np.array([0, 1, 1]).astype(env.NUMPY_FLOAT) + 10
-    p2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    p3 = np.array([1, 0, 0]).astype(env.NUMPY_FLOAT)
-    p4 = np.array([1, 1, 0]).astype(env.NUMPY_FLOAT)
-
-    dihedral = get_pbc_dihedral(p1, p2, p3, p4, pbc_matrix, pbc_inv)
-    assert dihedral == pytest.approx(- np.pi / 4)
-
-    p1 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    p2 = np.array([1, 0, 0]).astype(env.NUMPY_FLOAT)
-    p3 = np.array([0, 1, 0]).astype(env.NUMPY_FLOAT) - 10
-    p4 = np.array([0.5, 0.5, -1]).astype(env.NUMPY_FLOAT)
-
-    improper = get_pbc_dihedral(p1, p2, p3, p4, pbc_matrix, pbc_inv)
-    assert improper == pytest.approx(- np.pi / 2)
-
-    p1 = np.array([0, 1, 1]).astype(env.NUMPY_FLOAT)
-    p2 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
-    p3 = np.array([1, 0, 0]).astype(env.NUMPY_FLOAT)
-    p4 = np.array([1, 0, -1]).astype(env.NUMPY_FLOAT) - 10
-
-    dihedral = get_pbc_dihedral(p1, p2, p3, p4, pbc_matrix, pbc_inv)
-    assert dihedral == pytest.approx(- np.pi * 3/ 4)

--- a/mdpy/test/test_langevin_integrator.py
+++ b/mdpy/test/test_langevin_integrator.py
@@ -18,7 +18,7 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, 'data')
 out_dir = os.path.join(cur_dir, 'out')
 
-class TestVerletIntegrator:
+class TestLangevinIntegrator:
     def setup(self):
         pass
 
@@ -45,5 +45,5 @@ class TestVerletIntegrator:
         integrator.integrate(ensemble, 1)
 
         # ATOM      1  N   VAL A   1       2.347  -0.970   3.962  1.00  0.00      A    N
-        assert ensemble.state.positions[0, 1] == pytest.approx(-0.970, abs=0.01)
-        assert ensemble.state.positions[0, 0] == pytest.approx(2.347, abs=0.01)
+        assert ensemble.state.positions.get()[0, 1] == pytest.approx(-0.970, abs=0.01)
+        assert ensemble.state.positions.get()[0, 0] == pytest.approx(2.347, abs=0.01)

--- a/mdpy/test/test_neighbor_list.py
+++ b/mdpy/test/test_neighbor_list.py
@@ -44,7 +44,7 @@ class TestNeighborList:
     def test_update(self):
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
         self.neighbor_list.update(cp.array(pdb.positions, CUPY_FLOAT))
-        neighbor_list = self.neighbor_list.device_neighbor_list.get()
+        neighbor_list = self.neighbor_list.neighbor_list.get()
         for i in range(10):
             r = ((pdb.positions[0, :] - pdb.positions)**2).sum(1)
             r = np.sqrt(r)

--- a/mdpy/test/test_neighbor_list.py
+++ b/mdpy/test/test_neighbor_list.py
@@ -9,7 +9,9 @@ copyright : (C)Copyright 2021-present, mdpy organization
 
 import pytest, os
 import numpy as np
+import cupy as cp
 from mdpy.core import NeighborList
+from mdpy.environment import *
 from mdpy.io import PDBParser
 from mdpy.unit import *
 from mdpy.error import *
@@ -41,7 +43,7 @@ class TestNeighborList:
 
     def test_update(self):
         pdb = PDBParser(os.path.join(data_dir, '6PO6.pdb'))
-        self.neighbor_list.update(pdb.positions)
+        self.neighbor_list.update(cp.array(pdb.positions, CUPY_FLOAT))
         neighbor_list = self.neighbor_list.device_neighbor_list.get()
         for i in range(10):
             r = ((pdb.positions[0, :] - pdb.positions)**2).sum(1)
@@ -49,8 +51,3 @@ class TestNeighborList:
             for i in np.argwhere(r <= 4).flatten():
                 if i != 0:
                     assert i in list(neighbor_list[0, :])
-
-if __name__ == '__main__':
-    test = TestNeighborList()
-    test.setup()
-    test.test_update()

--- a/mdpy/test/test_pbc.py
+++ b/mdpy/test/test_pbc.py
@@ -14,7 +14,7 @@ from mdpy.utils import *
 from mdpy.error import *
 
 pbc_matrix = np.diag(np.ones(3)*10).astype(env.NUMPY_FLOAT)
-pbc_inv = np.linalg.inv(pbc_matrix).astype(env.NUMPY_FLOAT)
+pbc_diag = np.diagonal(pbc_matrix)
 
 def test_check_pbc_matrix():
     with pytest.raises(PBCPoorDefinedError):
@@ -34,27 +34,27 @@ def test_wrap_positions():
         [11, 12, 3],
         [-3, -12., -14]
     ])
-    wrapped_positions = wrap_positions(positions, pbc_matrix, pbc_inv)
+    wrapped_positions = wrap_positions(positions, np.diagonal(pbc_matrix))
     assert wrapped_positions[0, 0] == 0
     assert wrapped_positions[3, 0] == -4
-    assert wrapped_positions[1, 1] == -5
-    assert wrapped_positions[2, 2] == 5
+    assert wrapped_positions[1, 1] == 5
+    assert wrapped_positions[2, 2] == -5
     assert wrapped_positions[-1, 1] == -2
     assert wrapped_positions[-2, 0] == 1
     assert wrapped_positions[-2, 2] == 3
 
-    with pytest.raises(ParticleLossError):
-        wrap_positions(np.array([16, 0, 1]), pbc_matrix, pbc_inv)
+    # with pytest.raises(ParticleLossError):
+    #     wrap_positions(np.array([16, 0, 1]), pbc_matrix, pbc_inv)
 
 def test_unwrap_vec():
     vec = np.array([0, 6, 1]).astype(env.NUMPY_FLOAT)
-    unwrapped_vec = unwrap_vec(vec, pbc_matrix, pbc_inv)
+    unwrapped_vec = unwrap_vec(vec, pbc_diag)
     assert unwrapped_vec[0] == 0
     assert unwrapped_vec[1] == pytest.approx(-4)
     assert unwrapped_vec[2] == 1
 
     vec = np.array([-5, -6, 9]).astype(env.NUMPY_FLOAT)
-    unwrapped_vec = unwrap_vec(vec, pbc_matrix, pbc_inv)
+    unwrapped_vec = unwrap_vec(vec, pbc_diag)
     assert unwrapped_vec[0] == -5
     assert unwrapped_vec[1] == pytest.approx(4)
     assert unwrapped_vec[2] == pytest.approx(-1)
@@ -62,8 +62,8 @@ def test_unwrap_vec():
     p1 = np.array([0, 0, 0]).astype(env.NUMPY_FLOAT)
     p2 = np.array([0, 1, 0]).astype(env.NUMPY_FLOAT)
     vec1 = p1 - p2
-    vec2 = unwrap_vec(p1 + 10 - p2, pbc_matrix, pbc_inv)
-    vec3 = unwrap_vec(p1 - 10 - p2, pbc_matrix, pbc_inv)
+    vec2 = unwrap_vec(p1 + 10 - p2, pbc_diag)
+    vec3 = unwrap_vec(p1 - 10 - p2, pbc_diag)
     assert vec1[0] == pytest.approx(vec2[0])
     assert vec1[0] == pytest.approx(vec3[0])
     assert vec1[1] == pytest.approx(vec2[1])
@@ -76,6 +76,6 @@ def test_unwrap_vec():
         [0, 1, 0],
         [9, -1, 0],
         [0, 1, -8]
-    ]).astype(env.NUMPY_FLOAT), pbc_matrix, pbc_inv)
+    ]).astype(env.NUMPY_FLOAT), pbc_diag)
     assert vec[0, 1] == pytest.approx(-1)
     assert vec[3, 2] == pytest.approx(2)

--- a/mdpy/test/test_verlet_integrator.py
+++ b/mdpy/test/test_verlet_integrator.py
@@ -44,8 +44,5 @@ class TestVerletIntegrator:
         integrator.integrate(ensemble, 1)
 
         # ATOM      1  N   VAL A   1       2.347  -0.970   3.962  1.00  0.00      A    N
-        assert ensemble.state.positions[0, 1] == pytest.approx(-0.970, abs=0.01)
-        assert ensemble.state.positions[0, 0] == pytest.approx(2.347, abs=0.01)
-
-test = TestVerletIntegrator()
-test.test_integrate()
+        assert ensemble.state.positions.get()[0, 1] == pytest.approx(-0.970, abs=0.01)
+        assert ensemble.state.positions.get()[0, 0] == pytest.approx(2.347, abs=0.01)

--- a/mdpy/unit/quantity.py
+++ b/mdpy/unit/quantity.py
@@ -8,6 +8,7 @@ copyright : (C)Copyright 2021-present, mdpy organization
 '''
 
 import numpy as np
+import cupy as cp
 from copy import deepcopy
 from mdpy import env
 from mdpy.unit import Unit, QUANTITY_PRECISION
@@ -31,6 +32,8 @@ class Quantity:
         else:
             if isinstance(value, np.ndarray):
                 self._value = value.astype(env.NUMPY_FLOAT)
+            elif isinstance(value, cp.ndarray):
+                self._value = value.get().astype(env.NUMPY_FLOAT)
             else:
                 self._value = np.array(value).astype(env.NUMPY_FLOAT)
                 if self._value.shape == ():

--- a/mdpy/utils/__init__.py
+++ b/mdpy/utils/__init__.py
@@ -4,9 +4,9 @@ __copyright__ = "(C)Copyright 2021-present, mdpy organization"
 __license__ = "BSD"
 
 from mdpy.utils.geometry import get_unit_vec, get_norm_vec
-from mdpy.utils.geometry import get_bond, get_pbc_bond
-from mdpy.utils.geometry import get_angle, get_pbc_angle, get_included_angle
-from mdpy.utils.geometry import get_dihedral, get_pbc_dihedral
+from mdpy.utils.geometry import get_bond
+from mdpy.utils.geometry import get_angle, get_included_angle
+from mdpy.utils.geometry import get_dihedral
 from mdpy.utils.geometry import generate_rotation_matrix
 from mdpy.utils.pbc import check_pbc_matrix
 from mdpy.utils.pbc import wrap_positions, unwrap_vec
@@ -17,9 +17,9 @@ from mdpy.utils.select import SELECTION_SUPPORTED_STERIC_KEYWORDS, SELECTION_SUP
 
 __all__ = [
     'get_unit_vec', 'get_norm_vec',
-    'get_bond', 'get_pbc_bond',
-    'get_angle', 'get_pbc_angle', 'get_included_angle',
-    'get_dihedral', 'get_pbc_dihedral',
+    'get_bond',
+    'get_angle', 'get_included_angle',
+    'get_dihedral',
     'generate_rotation_matrix',
     'check_pbc_matrix',
     'wrap_positions', 'unwrap_vec',

--- a/mdpy/utils/geometry.py
+++ b/mdpy/utils/geometry.py
@@ -29,10 +29,6 @@ def get_norm_vec(p1, p2, p3):
 def get_bond(p1, p2):
     return np.linalg.norm(np.array(p1) - np.array(p2))
 
-def get_pbc_bond(p1, p2, pbc_matrix, pbc_inv):
-    bond_vec = unwrap_vec(np.array(p1) - np.array(p2), pbc_matrix, pbc_inv)
-    return np.linalg.norm(bond_vec)
-
 def get_angle(p1, p2, p3, is_angular=True):
     p1, p2, p3 = np.array(p1), np.array(p2), np.array(p3)
     v0 = p1 - p2
@@ -42,13 +38,6 @@ def get_angle(p1, p2, p3, is_angular=True):
         return arccos(cos_phi)
     else:
         return arccos(cos_phi) / np.pi * 180
-
-@nb.njit()
-def get_pbc_angle(p1, p2, p3, pbc_matrix, pbc_inv):
-    v0 = unwrap_vec(p1 - p2, pbc_matrix, pbc_inv)
-    v1 = unwrap_vec(p3 - p2, pbc_matrix, pbc_inv)
-    cos_phi = np.dot(v0, v1) / (np.linalg.norm(v0)*np.linalg.norm(v1))
-    return arccos(cos_phi)
 
 def get_included_angle(vec1, vec2, is_angular=True):
     cos_phi = np.dot(vec1, vec2) / (np.linalg.norm(vec1)*np.linalg.norm(vec2))
@@ -74,20 +63,6 @@ def get_dihedral(p1, p2, p3, p4, is_angular=True):
         return np.arctan2(x, y)
     else:
         return np.arctan2(x, y) / np.pi * 180
-
-@nb.njit()
-def get_pbc_dihedral(p1, p2, p3, p4, pbc_matrix, pbc_inv):
-    r1 = unwrap_vec(p2 - p1, pbc_matrix, pbc_inv)
-    r2 = unwrap_vec(p3 - p2, pbc_matrix, pbc_inv)
-    r3 = unwrap_vec(p4 - p3, pbc_matrix, pbc_inv)
-
-    n1 = np.cross(r1, r2)
-    n2 = np.cross(r2, r3)
-
-    x = np.dot(np.linalg.norm(r2) * r1, n2)
-    y = np.dot(n1, n2)
-
-    return np.arctan2(x, y)
 
 def generate_rotation_matrix(yaw, pitch, roll):
     shape = [SPATIAL_DIM, SPATIAL_DIM]

--- a/mdpy/utils/select.py
+++ b/mdpy/utils/select.py
@@ -165,7 +165,7 @@ def select_nearby(target: Trajectory, frame, matrix_ids, radius):
     for matrix_id in matrix_ids:
         vec = unwrap_vec(
             trajectory.positions[frame, matrix_id, :] - trajectory.positions[frame, :, :],
-            trajectory.pbc_matrix, trajectory.pbc_inv
+            trajectory.pbc_diag
         )
         temp = list(np.where(np.sqrt((vec**2).sum(1)) < radius)[0])
         temp.remove(matrix_id)
@@ -182,7 +182,7 @@ def select_in_sphere(target: Trajectory, frame, center, radius):
     selected_matrix_ids = []
     vec = unwrap_vec(
         center - trajectory.positions[frame, :, :],
-        trajectory.pbc_matrix, trajectory.pbc_inv
+        trajectory.pbc_diag
     )
     selected_matrix_ids.extend(
         list(np.where(np.sqrt((vec**2).sum(1)) < radius))


### PR DESCRIPTION
# Overview
4 array will be `cupy.ndarray` without specifying device as prefix:
- `forces`
- `positions`
- `velocities`
- `neighbor_list`
Other device variable will contain `device` prefix like `device_cutoff_radius`

Update `integrator` and `minimizer` to update with `cupy.ndarray`
Update `mdpy.core.State` class, support `cupy.ndarray`
Add multi-steam to `mdpy.core.Ensemble`